### PR TITLE
Remove the API protocol and make it a class instead.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,6 +21,10 @@ jobs:
       - uses: fwal/setup-swift@v1
         with:
           swift-version: "5.6"
+      - name: Install Sourcery
+        run: brew update && brew install sourcery
+      - name: Check Flat API
+        run: ./flat-api.sh -c
       - name: Build tools & Lint
         if: steps.cache-spm.outputs.cache-hit != 'true'
         run: swift run -c release --package-path BuildTools swift-format lint -p --strict --recursive ./Sources ./Tests ./scripts

--- a/Sources/TwitterAPIKit/APIv1/Account/AccountAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Account/AccountAPIv1.swift
@@ -1,79 +1,50 @@
 import Foundation
 
-public protocol AccountAPIv1 {
+open class AccountAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-account-settings
-    func getAccountSetting(
-        _ request: GetAccountSettingsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
-    func getAccountVerify(
-        _ request: GetAccountVerifyCredentialsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-remove_profile_banner
-    func postRemoveProfileBanner(
-        _ request: PostAccountRemoveProfileBannerRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-settings
-    func postAccountSettings(
-        _ request: PostAccountSettingsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile
-    func postAccountProfile(
-        _ request: PostAccountUpdateProfileRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_banner
-    func postProfileBanner(
-        _ request: PostAccountUpdateProfileBannerRequestV1
-    ) -> TwitterAPISessionDataTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_image
-    func postProfileImage(
-        _ request: PostAccountUpdateProfileImageRequestV1
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: AccountAPIv1 {
     public func getAccountSetting(
         _ request: GetAccountSettingsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
     public func getAccountVerify(
         _ request: GetAccountVerifyCredentialsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-remove_profile_banner
     public func postRemoveProfileBanner(
         _ request: PostAccountRemoveProfileBannerRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-settings
     public func postAccountSettings(
         _ request: PostAccountSettingsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
+
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile
     public func postAccountProfile(
         _ request: PostAccountUpdateProfileRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_banner
     public func postProfileBanner(
         _ request: PostAccountUpdateProfileBannerRequestV1
     ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_image
     public func postProfileImage(
         _ request: PostAccountUpdateProfileImageRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv1/Application/ApplicationAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Application/ApplicationAPIv1.swift
@@ -1,16 +1,11 @@
 import Foundation
 
-public protocol ApplicationAPIv1 {
+open class ApplicationAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/developer-utilities/rate-limit-status/api-reference/get-application-rate_limit_status
-    func getRateLimit(
+    public func getRateLimit(
         _ request: GetApplicationRateLimitStatusRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: ApplicationAPIv1 {
-    func getRateLimit(_ request: GetApplicationRateLimitStatusRequestV1) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv1/BlockAndMute/BlockAndMuteAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/BlockAndMute/BlockAndMuteAPIv1.swift
@@ -1,104 +1,64 @@
 import Foundation
 
-public protocol BlockAndMuteAPIv1 {
+open class BlockAndMuteAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/get-blocks-ids
-    func getBlockIDs(
-        _ request: GetBlocksIDsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/get-blocks-list
-    func getBlockUsers(
-        _ request: GetBlocksListRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-ids
-    func getMuteIDs(
-        _ request: GetMutesUsersIDsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-list
-    func getMuteUsers(
-        _ request: GetMutesUsersListRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-blocks-create
-    func postBlockUser(
-        _ request: PostBlocksCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-blocks-destroy
-    func postUnblockUser(
-        _ request: PostBlocksDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
-    func postMuteUser(
-        _ request: PostMutesUsersCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-destroy
-    func postUnmuteUser(
-        _ request: PostMutesUsersDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-users-report_spam
-    func postReportSpam(
-        _ request: PostUsersReportSpamRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: BlockAndMuteAPIv1 {
-
     public func getBlockIDs(
         _ request: GetBlocksIDsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/get-blocks-list
     public func getBlockUsers(
         _ request: GetBlocksListRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-ids
     public func getMuteIDs(
         _ request: GetMutesUsersIDsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-list
     public func getMuteUsers(
         _ request: GetMutesUsersListRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-blocks-create
     public func postBlockUser(
         _ request: PostBlocksCreateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-blocks-destroy
     public func postUnblockUser(
         _ request: PostBlocksDestroyRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
     public func postMuteUser(
         _ request: PostMutesUsersCreateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-destroy
     public func postUnmuteUser(
         _ request: PostMutesUsersDestroyRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-users-report_spam
     public func postReportSpam(
         _ request: PostUsersReportSpamRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv1/Collection/CollectionAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Collection/CollectionAPIv1.swift
@@ -1,115 +1,72 @@
 import Foundation
 
-public protocol CollectionAPIv1 {
+open class CollectionAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/get-collections-entries
-    func getCollectionEntries(
+    public func getCollectionEntries(
         _ request: GetCollectionsEntriesRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/get-collections-list
-    func getCollections(
+    public func getCollections(
         _ request: GetCollectionsListRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/get-collections-show
-    func getCollection(
+    public func getCollection(
         _ request: GetCollectionsShowRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-create
-    func postCreateCollection(
+    public func postCreateCollection(
         _ request: PostCollectionsCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-destroy
-    func postDestroyCollection(
+    public func postDestroyCollection(
         _ request: PostCollectionsDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-entries-add
-    func postCollectionAddEntry(
+    public func postCollectionAddEntry(
         _ request: PostCollectionsEntriesAddRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-entries-curate
-    func postCollectionCurate(
+    public func postCollectionCurate(
         _ request: PostCollectionsEntriesCurateRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-entries-move
-    func postCollectionMoveEntry(
+    public func postCollectionMoveEntry(
         _ request: PostCollectionsEntriesMoveRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-entries-remove
-    func postCollectionRemoveEntry(
+    public func postCollectionRemoveEntry(
         _ request: PostCollectionsEntriesRemoveRequestV1
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/curate-a-collection/api-reference/post-collections-update
-    func postCollectionUpdate(
-        _ request: PostCollectionsUpdateRequestV1
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: CollectionAPIv1 {
-
-    func getCollectionEntries(
-        _ request: GetCollectionsEntriesRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getCollections(
-        _ request: GetCollectionsListRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getCollection(
-        _ request: GetCollectionsShowRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func postCreateCollection(
-        _ request: PostCollectionsCreateRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func postDestroyCollection(
-        _ request: PostCollectionsDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func postCollectionAddEntry(
-        _ request: PostCollectionsEntriesAddRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func postCollectionCurate(
-        _ request: PostCollectionsEntriesCurateRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func postCollectionMoveEntry(
-        _ request: PostCollectionsEntriesMoveRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func postCollectionRemoveEntry(
-        _ request: PostCollectionsEntriesRemoveRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func postCollectionUpdate(
+    public func postCollectionUpdate(
         _ request: PostCollectionsUpdateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)

--- a/Sources/TwitterAPIKit/APIv1/DirectMessage/DirectMessageAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/DirectMessage/DirectMessageAPIv1.swift
@@ -1,71 +1,44 @@
 import Foundation
 
-public protocol DirectMessageAPIv1 {
+open class DirectMessageAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/new-event
-    func postDirectMessage(
-        _ request: PostDirectMessageRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/delete-message-event
-    func deleteDirectMessage(
-        _ request: DeleteDirectMessageRequestV1
-    ) -> TwitterAPISessionDataTask  // 204 - No Content
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/get-event
-    func getDirectMessage(
-        _ request: GetDirectMessageRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/list-events
-    func getDirectMessageList(
-        _ request: GetDirectMessageListRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-read-receipt
-    func postDirectMessageMarkRead(
-        _ request: PostDirectMessagesMarkReadRequestV1
-    ) -> TwitterAPISessionDataTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-typing-indicator
-    func postDirectMessageTypingIndicator(
-        _ request: PostDirectMessagesIndicateTypingRequestV1
-    ) -> TwitterAPISessionDataTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: DirectMessageAPIv1 {
-
     public func postDirectMessage(
         _ request: PostDirectMessageRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/delete-message-event
     public func deleteDirectMessage(
         _ request: DeleteDirectMessageRequestV1
-    ) -> TwitterAPISessionDataTask {
+    ) -> TwitterAPISessionDataTask {  // 204 - No Content
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/get-event
     public func getDirectMessage(
         _ request: GetDirectMessageRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/sending-and-receiving/api-reference/list-events
     public func getDirectMessageList(
         _ request: GetDirectMessageListRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
-    func postDirectMessageMarkRead(
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-read-receipt
+    public func postDirectMessageMarkRead(
         _ request: PostDirectMessagesMarkReadRequestV1
     ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 
-    func postDirectMessageTypingIndicator(
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/direct-messages/typing-indicator-and-read-receipts/api-reference/new-typing-indicator
+    public func postDirectMessageTypingIndicator(
         _ request: PostDirectMessagesIndicateTypingRequestV1
     ) -> TwitterAPISessionDataTask {
         return session.send(request)

--- a/Sources/TwitterAPIKit/APIv1/Favorite/FavoriteAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Favorite/FavoriteAPIv1.swift
@@ -1,39 +1,24 @@
 import Foundation
 
-public protocol FavoriteAPIv1 {
+open class FavoriteAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-favorites-create
-    func postFavorite(
-        _ request: PostFavoriteRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-favorites-destroy
-    func postUnFavorite(
-        _ request: PostUnFavoriteRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-favorites-list
-    func getFavorites(
-        _ request: GetFavoritesRequestV1
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: FavoriteAPIv1 {
-
-    public func getFavorites(
-        _ request: GetFavoritesRequestV1
-    ) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
     public func postFavorite(
         _ request: PostFavoriteRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-favorites-destroy
     public func postUnFavorite(
         _ request: PostUnFavoriteRequestV1
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
+
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-favorites-list
+    public func getFavorites(
+        _ request: GetFavoritesRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }

--- a/Sources/TwitterAPIKit/APIv1/Friendships/FriendshipsAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Friendships/FriendshipsAPIv1.swift
@@ -1,137 +1,85 @@
 import Foundation
 
-public protocol FriendshipsAPIv1 {
+open class FriendshipsAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids
-    func getFollowerIDs(
-        _ request: GetFollowersIDsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-followers-list
-    func getFollowers(
-        _ request: GetFollowersListRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids
-    func getFriendIDs(
-        _ request: GetFriendsIDsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friends-list
-    func getFriends(
-        _ request: GetFriendsListRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming
-    func getFriendshipsIncoming(
-        _ request: GetFriendshipsIncomingRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup
-    func getFriendshipsLookup(
-        _ request: GetFriendshipsLookupRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-no_retweets-ids
-    func getFriendshipsNoRetweetsIDs(
-        _ request: GetFriendshipsNoRetweetsIDsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing
-    func getFriendshipsOutgoing(
-        _ request: GetFriendshipsOutgoingRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-show
-    func getFriendships(
-        _ request: GetFriendshipsShowRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/post-friendships-create
-    func postFollowUser(
-        _ request: PostFriendshipsCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/post-friendships-destroy
-    func postUnfollowUser(
-        _ request: PostFriendshipsDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/post-friendships-update
-    func postFriendshipsUpdate(
-        _ request: PostFriendshipsUpdateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: FriendshipsAPIv1 {
-
     public func getFollowerIDs(
         _ request: GetFollowersIDsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-followers-list
     public func getFollowers(
         _ request: GetFollowersListRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids
     public func getFriendIDs(
         _ request: GetFriendsIDsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friends-list
     public func getFriends(
         _ request: GetFriendsListRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming
     public func getFriendshipsIncoming(
         _ request: GetFriendshipsIncomingRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup
     public func getFriendshipsLookup(
         _ request: GetFriendshipsLookupRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-no_retweets-ids
     public func getFriendshipsNoRetweetsIDs(
         _ request: GetFriendshipsNoRetweetsIDsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing
     public func getFriendshipsOutgoing(
         _ request: GetFriendshipsOutgoingRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-friendships-show
     public func getFriendships(
         _ request: GetFriendshipsShowRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/post-friendships-create
     public func postFollowUser(
         _ request: PostFriendshipsCreateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/post-friendships-destroy
     public func postUnfollowUser(
         _ request: PostFriendshipsDestroyRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/post-friendships-update
     public func postFriendshipsUpdate(
         _ request: PostFriendshipsUpdateRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv1/Geo/GeoAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Geo/GeoAPIv1.swift
@@ -1,38 +1,22 @@
 import Foundation
 
-public protocol GeoAPIv1 {
+open class GeoAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/geo/places-near-location/api-reference/get-geo-reverse_geocode
-    func getReverseGeocode(
-        _ request: GetGeoReverseGeocodeRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/geo/place-information/api-reference/get-geo-id-place_id
-    func getGeoPlace(
-        _ request: GetGeoPlaceIDRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/geo/places-near-location/api-reference/get-geo-search
-    func searchGeo(
-        _ request: GetGeoSearchRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: GeoAPIv1 {
-
     public func getReverseGeocode(
         _ request: GetGeoReverseGeocodeRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/geo/place-information/api-reference/get-geo-id-place_id
     public func getGeoPlace(
         _ request: GetGeoPlaceIDRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/geo/places-near-location/api-reference/get-geo-search
     public func searchGeo(
         _ request: GetGeoSearchRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv1/Help/HelpAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Help/HelpAPIv1.swift
@@ -1,15 +1,9 @@
 import Foundation
 
-public protocol HelpAPIv1 {
+open class HelpAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/developer-utilities/supported-languages/api-reference/get-help-languages
-    func getSupportedLanguages(
-        _ request: GetHelpLanguagesRequestV1
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: HelpAPIv1 {
-    func getSupportedLanguages(
+    public func getSupportedLanguages(
         _ request: GetHelpLanguagesRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)

--- a/Sources/TwitterAPIKit/APIv1/List/ListAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/List/ListAPIv1.swift
@@ -1,214 +1,134 @@
 import Foundation
 
-public protocol ListAPIv1 {
+open class ListAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-list
-    func getLists(
-        _ request: GetListsListRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-members
-    func getListMembers(
-        _ request: GetListsMembersRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show
-    func getListMember(
-        _ request: GetListsMembersShowRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-memberships
-    func getListMemberships(
-        _ request: GetListsMembershipsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-ownerships
-    func getListOwnerships(
-        _ request: GetListsOwnershipsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-show
-    func getList(
-        _ request: GetListsShowRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses
-    func getListStatuses(
-        _ request: GetListsStatusesRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-subscribers
-    func getListSubscribers(
-        _ request: GetListsSubscribersRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-subscribers-show
-    func getListSubscriber(
-        _ request: GetListsSubscribersShowRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-subscriptions
-    func getListSubscriptions(
-        _ request: GetListsSubscriptionsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-create
-    func postCreateList(
-        _ request: PostListsCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-destroy
-    func postDestroyList(
-        _ request: PostListsDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-create
-    func postAddListMember(
-        _ request: PostListsMembersCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-create_all
-    func postAddListMembers(
-        _ request: PostListsMembersCreateAllRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy
-    func postRemoveListMember(
-        _ request: PostListsMembersDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy_all
-    func postRemoveListMembers(
-        _ request: PostListsMembersDestroyAllRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-subscribers-create
-    func postSubscribeList(
-        _ request: PostListsSubscribersCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-subscribers-destroy
-    func postUnsubscribeList(
-        _ request: PostListsSubscribersDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-update
-    func postUpdateList(
-        _ request: PostListsUpdateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: ListAPIv1 {
-
     public func getLists(
         _ request: GetListsListRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-members
     public func getListMembers(
         _ request: GetListsMembersRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show
     public func getListMember(
         _ request: GetListsMembersShowRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-memberships
     public func getListMemberships(
         _ request: GetListsMembershipsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-ownerships
     public func getListOwnerships(
         _ request: GetListsOwnershipsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-show
     public func getList(
         _ request: GetListsShowRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses
     public func getListStatuses(
         _ request: GetListsStatusesRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-subscribers
     public func getListSubscribers(
         _ request: GetListsSubscribersRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-subscribers-show
     public func getListSubscriber(
         _ request: GetListsSubscribersShowRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-subscriptions
     public func getListSubscriptions(
         _ request: GetListsSubscriptionsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-create
     public func postCreateList(
         _ request: PostListsCreateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-destroy
     public func postDestroyList(
         _ request: PostListsDestroyRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-create
     public func postAddListMember(
         _ request: PostListsMembersCreateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-create_all
     public func postAddListMembers(
         _ request: PostListsMembersCreateAllRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy
     public func postRemoveListMember(
         _ request: PostListsMembersDestroyRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy_all
     public func postRemoveListMembers(
         _ request: PostListsMembersDestroyAllRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-subscribers-create
     public func postSubscribeList(
         _ request: PostListsSubscribersCreateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-subscribers-destroy
     public func postUnsubscribeList(
         _ request: PostListsSubscribersDestroyRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/post-lists-update
     public func postUpdateList(
         _ request: PostListsUpdateRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv1/Media/MediaAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Media/MediaAPIv1.swift
@@ -1,106 +1,33 @@
 import Foundation
 
-public protocol MediaAPIv1 {
+open class MediaAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/get-media-upload-status
-    func getUploadMediaStatus(
-        _ request: GetUploadMediaStatusRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-upload-init
-    func uploadMediaInit(
-        _ request: UploadMediaInitRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-upload-append
-    func uploadMediaAppend(
-        _ request: UploadMediaAppendRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// Utility method for split uploading of large files.
-    func uploadMediaAppendSplitChunks(
-        _ request: UploadMediaAppendRequestV1,
-        maxBytes: Int
-    ) -> [TwitterAPISessionSpecializedTask<String /* mediaID */>]
-
-    func uploadMediaAppendSplitChunks(
-        _ request: UploadMediaAppendRequestV1
-    ) -> [TwitterAPISessionSpecializedTask<String /* mediaID */>]
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-upload-finalize
-    func uploadMediaFinalize(
-        _ request: UploadMediaFinalizeRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// Upload media utility method.
-    /// INIT -> APPEND x n -> FINALIZE -> STATUS x n (If needed)
-    func uploadMedia(
-        _ parameters: UploadMediaRequestParameters,
-        completionHandler: @escaping (
-            TwitterAPIResponse<String>
-        ) -> Void
-    )
-
-    func waitMediaProcessing(
-        mediaID: String,
-        initialWaitSec: Int,
-        completionHandler: @escaping (
-            TwitterAPIResponse<TwitterAPIClient.UploadMediaStatusResponse>
-        ) -> Void
-    )
-
-    func waitMediaProcessing(
-        mediaID: String,
-        completionHandler: @escaping (
-            TwitterAPIResponse<TwitterAPIClient.UploadMediaStatusResponse>
-        ) -> Void
-    )
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-metadata-create
-    func createMediaMetadata(
-        _ request: PostMediaMetadataCreateRequestV1
-    ) -> TwitterAPISessionDataTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-subtitles-create
-    func createSubtitle(
-        _ request: PostMediaSubtitlesCreateRequestV1
-    ) -> TwitterAPISessionDataTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-subtitles-delete
-    func deleteSubtitle(
-        _ request: PostMediaSubtitlesDeleteRequestV1
-    ) -> TwitterAPISessionDataTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: MediaAPIv1 {
-
     public func getUploadMediaStatus(
         _ request: GetUploadMediaStatusRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-upload-init
     public func uploadMediaInit(
         _ request: UploadMediaInitRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-upload-append
     public func uploadMediaAppend(
         _ request: UploadMediaAppendRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
-    func uploadMediaAppendSplitChunks(
-        _ request: UploadMediaAppendRequestV1
-    ) -> [TwitterAPISessionSpecializedTask<String>] {
-        return uploadMediaAppendSplitChunks(request, maxBytes: 5_242_880 /* 5MB */)
-    }
-
-    func uploadMediaAppendSplitChunks(
-        _ request: UploadMediaAppendRequestV1, maxBytes: Int
-    ) -> [TwitterAPISessionSpecializedTask<String>] {
+    /// Utility method for split uploading of large files.
+    public func uploadMediaAppendSplitChunks(
+        _ request: UploadMediaAppendRequestV1,
+        maxBytes: Int = 5_242_880 /* 5MB */
+    ) -> [TwitterAPISessionSpecializedTask<String /* mediaID */>] {
 
         let tasks = request.segments(maxBytes: maxBytes)
             .map { req in
@@ -108,16 +35,18 @@ extension TwitterAPIClient.TwitterAPIImplV1: MediaAPIv1 {
                     req.mediaID
                 }
             }
-
         return tasks
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-upload-finalize
     public func uploadMediaFinalize(
         _ request: UploadMediaFinalizeRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// Upload media utility method.
+    /// INIT -> APPEND x n -> FINALIZE -> STATUS x n (If needed)
     public func uploadMedia(
         _ parameters: UploadMediaRequestParameters,
         completionHandler: @escaping (
@@ -252,15 +181,24 @@ extension TwitterAPIClient.TwitterAPIImplV1: MediaAPIv1 {
             }
     }
 
-    func createMediaMetadata(_ request: PostMediaMetadataCreateRequestV1) -> TwitterAPISessionDataTask {
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-metadata-create
+    public func createMediaMetadata(
+        _ request: PostMediaMetadataCreateRequestV1
+    ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 
-    func createSubtitle(_ request: PostMediaSubtitlesCreateRequestV1) -> TwitterAPISessionDataTask {
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-subtitles-create
+    public func createSubtitle(
+        _ request: PostMediaSubtitlesCreateRequestV1
+    ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 
-    func deleteSubtitle(_ request: PostMediaSubtitlesDeleteRequestV1) -> TwitterAPISessionDataTask {
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/media/upload-media/api-reference/post-media-subtitles-delete
+    public func deleteSubtitle(
+        _ request: PostMediaSubtitlesDeleteRequestV1
+    ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv1/Retweet/RetweetAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Retweet/RetweetAPIv1.swift
@@ -1,58 +1,36 @@
 import Foundation
 
-public protocol RetweetAPIv1 {
+open class RetweetAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-retweet-id
-    func postRetweet(
-        _ request: PostRetweetRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-unretweet-id
-    func postUnRetweet(
-        _ request: PostUnRetweetRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-retweets-id
-    func getRetweets(
-        _ request: GetRetweetsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-retweets_of_me
-    func getRetweetsOfMe(
-        _ request: GetRetweetsOfMeRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids
-    func getRetweeters(
-        _ request: GetRetweetersRequestV1
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: RetweetAPIv1 {
     public func postRetweet(
         _ request: PostRetweetRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-unretweet-id
     public func postUnRetweet(
         _ request: PostUnRetweetRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-retweets-id
     public func getRetweets(
         _ request: GetRetweetsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-retweets_of_me
     public func getRetweetsOfMe(
         _ request: GetRetweetsOfMeRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids
     public func getRetweeters(
         _ request: GetRetweetersRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv1/Search/SearchAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Search/SearchAPIv1.swift
@@ -1,49 +1,29 @@
 import Foundation
 
-public protocol SearchAPIv1 {
+open class SearchAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/search/api-reference/get-search-tweets
-    func searchTweets(
-        _ request: GetSearchTweetsRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-saved_searches-list
-    func getSavedSearches(
-        _ request: GetSavedSearchesListRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-saved_searches-create
-    func postCreateSavedSearch(
-        _ request: PostSavedSearchesCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-saved_searches-destroy-id
-    func postDestroySavedSearch(
-        _ request: PostSavedSearchesCreateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: SearchAPIv1 {
-
     public func searchTweets(
         _ request: GetSearchTweetsRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-saved_searches-list
     public func getSavedSearches(
         _ request: GetSavedSearchesListRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-saved_searches-create
     public func postCreateSavedSearch(
         _ request: PostSavedSearchesCreateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/post-saved_searches-destroy-id
     public func postDestroySavedSearch(
         _ request: PostSavedSearchesCreateRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv1/Timelines/TimelineAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Timelines/TimelineAPIv1.swift
@@ -1,42 +1,26 @@
 import Foundation
 
 /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/timelines/overview
-public protocol TimelineAPIv1 {
+open class TimelineAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/timelines/api-reference/get-statuses-home_timeline
-    func getHomeTimeline(
-        _ request: GetStatusesHomeTimelineRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/timelines/api-reference/get-statuses-mentions_timeline
-    func getMentionsTimeline(
-        _ request: GetStatusesMentionsTimelineRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/timelines/api-reference/get-statuses-user_timeline
-    func getUserTimeline(
-        _ request: GetStatusesUserTimelineRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: TimelineAPIv1 {
     public func getHomeTimeline(
         _ request: GetStatusesHomeTimelineRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/timelines/api-reference/get-statuses-mentions_timeline
     public func getMentionsTimeline(
         _ request: GetStatusesMentionsTimelineRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/timelines/api-reference/get-statuses-user_timeline
     public func getUserTimeline(
         _ request: GetStatusesUserTimelineRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
-
 }

--- a/Sources/TwitterAPIKit/APIv1/Trend/TrendAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Trend/TrendAPIv1.swift
@@ -1,38 +1,22 @@
 import Foundation
 
-public protocol TrendAPIv1 {
+open class TrendAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/trends/locations-with-trending-topics/api-reference/get-trends-available
-    func getTrendsAvailable(
-        _ request: GetTrendsAvailableRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/trends/locations-with-trending-topics/api-reference/get-trends-closest
-    func getTrendsClosest(
-        _ request: GetTrendsClosestRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/trends/trends-for-location/api-reference/get-trends-place
-    func getTrends(
-        _ request: GetTrendsPlaceRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: TrendAPIv1 {
-
     public func getTrendsAvailable(
         _ request: GetTrendsAvailableRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/trends/locations-with-trending-topics/api-reference/get-trends-closest
     public func getTrendsClosest(
         _ request: GetTrendsClosestRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/trends/trends-for-location/api-reference/get-trends-place
     public func getTrends(
         _ request: GetTrendsPlaceRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv1/Tweet/TweetAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Tweet/TweetAPIv1.swift
@@ -1,54 +1,35 @@
 import Foundation
 
-public protocol TweetAPIv1 {
+open class TweetAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-update
-    func postUpdateStatus(
-        _ request: PostStatusesUpdateRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-destroy-id
-    func postDestroyStatus(
-        _ request: PostStatusesDestroyRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-show-id
-    func getShowStatus(
-        _ request: GetStatusesShowRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-lookup
-    func getLookupStatuses(
-        _ request: GetStatusesLookupRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-oembed
-    // TODO↑
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: TweetAPIv1 {
-
     public func postUpdateStatus(
         _ request: PostStatusesUpdateRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-destroy-id
     public func postDestroyStatus(
         _ request: PostStatusesDestroyRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-show-id
     public func getShowStatus(
         _ request: GetStatusesShowRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-lookup
     public func getLookupStatuses(
         _ request: GetStatusesLookupRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
+
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/get-statuses-oembed
+    // TODO↑
 }

--- a/Sources/TwitterAPIKit/APIv1/TwitterAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/TwitterAPIv1.swift
@@ -1,61 +1,40 @@
-public typealias TwitterAPIv1 =
-    TwitterAPIResourceV1
-    // sorted
-    & AccountAPIv1
-    & ApplicationAPIv1
-    & BlockAndMuteAPIv1
-    & CollectionAPIv1
-    & DirectMessageAPIv1
-    & FavoriteAPIv1
-    & FriendshipsAPIv1
-    & GeoAPIv1
-    & HelpAPIv1
-    & ListAPIv1
-    & MediaAPIv1
-    & RetweetAPIv1
-    & SearchAPIv1
-    & TimelineAPIv1
-    & TrendAPIv1
-    & TweetAPIv1
-    & UserAPIv1
+open class TwitterAPIv1: TwitterAPIBase {
+    public let account: AccountAPIv1
+    public let application: ApplicationAPIv1
+    public let blockAndMute: BlockAndMuteAPIv1
+    public let collection: CollectionAPIv1
+    public let directMessage: DirectMessageAPIv1
+    public let favorite: FavoriteAPIv1
+    public let friendships: FriendshipsAPIv1
+    public let geo: GeoAPIv1
+    public let help: HelpAPIv1
+    public let list: ListAPIv1
+    public let media: MediaAPIv1
+    public let retweet: RetweetAPIv1
+    public let search: SearchAPIv1
+    public let timeline: TimelineAPIv1
+    public let trend: TrendAPIv1
+    public let tweet: TweetAPIv1
+    public let user: UserAPIv1
 
-public protocol TwitterAPIResourceV1 {
-    var account: AccountAPIv1 { get }
-    var application: ApplicationAPIv1 { get }
-    var blockAndMute: BlockAndMuteAPIv1 { get }
-    var collection: CollectionAPIv1 { get }
-    var directMessage: DirectMessageAPIv1 { get }
-    var favorite: FavoriteAPIv1 { get }
-    var friendships: FriendshipsAPIv1 { get }
-    var geo: GeoAPIv1 { get }
-    var help: HelpAPIv1 { get }
-    var list: ListAPIv1 { get }
-    var media: MediaAPIv1 { get }
-    var retweet: RetweetAPIv1 { get }
-    var search: SearchAPIv1 { get }
-    var timeline: TimelineAPIv1 { get }
-    var trend: TrendAPIv1 { get }
-    var tweet: TweetAPIv1 { get }
-    var user: UserAPIv1 { get }
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: TwitterAPIResourceV1 {
-    var account: AccountAPIv1 { return self }
-    var application: ApplicationAPIv1 { return self }
-    var blockAndMute: BlockAndMuteAPIv1 { return self }
-    var collection: CollectionAPIv1 { return self }
-    var directMessage: DirectMessageAPIv1 { return self }
-    var favorite: FavoriteAPIv1 { return self }
-    var friendships: FriendshipsAPIv1 { return self }
-    var geo: GeoAPIv1 { return self }
-    var help: HelpAPIv1 { return self }
-    var list: ListAPIv1 { return self }
-    var media: MediaAPIv1 { return self }
-    var retweet: RetweetAPIv1 { return self }
-    var search: SearchAPIv1 { return self }
-    var timeline: TimelineAPIv1 { return self }
-    var trend: TrendAPIv1 { return self }
-    var tweet: TweetAPIv1 { return self }
-    var user: UserAPIv1 { return self }
+    public override init(session: TwitterAPISession) {
+        account = .init(session: session)
+        application = .init(session: session)
+        blockAndMute = .init(session: session)
+        collection = .init(session: session)
+        directMessage = .init(session: session)
+        favorite = .init(session: session)
+        friendships = .init(session: session)
+        geo = .init(session: session)
+        help = .init(session: session)
+        list = .init(session: session)
+        media = .init(session: session)
+        retweet = .init(session: session)
+        search = .init(session: session)
+        timeline = .init(session: session)
+        trend = .init(session: session)
+        tweet = .init(session: session)
+        user = .init(session: session)
+        super.init(session: session)
+    }
 }

--- a/Sources/TwitterAPIKit/APIv1/TwitterAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/TwitterAPIv1.swift
@@ -1,4 +1,4 @@
-open class TwitterAPIv1: TwitterAPIBase {
+open class TwitterAPIv1 {
     public let account: AccountAPIv1
     public let application: ApplicationAPIv1
     public let blockAndMute: BlockAndMuteAPIv1
@@ -17,7 +17,7 @@ open class TwitterAPIv1: TwitterAPIBase {
     public let tweet: TweetAPIv1
     public let user: UserAPIv1
 
-    public override init(session: TwitterAPISession) {
+    public init(session: TwitterAPISession) {
         account = .init(session: session)
         application = .init(session: session)
         blockAndMute = .init(session: session)
@@ -35,6 +35,5 @@ open class TwitterAPIv1: TwitterAPIBase {
         trend = .init(session: session)
         tweet = .init(session: session)
         user = .init(session: session)
-        super.init(session: session)
     }
 }

--- a/Sources/TwitterAPIKit/APIv1/Users/UserAPIv1.swift
+++ b/Sources/TwitterAPIKit/APIv1/Users/UserAPIv1.swift
@@ -1,48 +1,29 @@
 import Foundation
 
-public protocol UserAPIv1 {
+open class UserAPIv1: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-users-lookup
-    func getUsers(
-        _ request: GetUsersLookupRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-users-show
-    func getUser(
-        _ request: GetUsersShowRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-users-search
-    func searchUser(
-        _ request: GetUsersShowRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-users-profile_banner
-    func getUserProfileBanner(
-        _ request: GetUsersProfileBannerRequestV1
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV1: UserAPIv1 {
-
     public func getUsers(
         _ request: GetUsersLookupRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-users-show
     public func getUser(
         _ request: GetUsersShowRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/follow-search-get-users/api-reference/get-users-search
     public func searchUser(
         _ request: GetUsersShowRequestV1
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/manage-account-settings/api-reference/get-users-profile_banner
     public func getUserProfileBanner(
         _ request: GetUsersProfileBannerRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv2/BlockAndMute/BlockAndMuteAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/BlockAndMute/BlockAndMuteAPIv2.swift
@@ -1,61 +1,46 @@
 import Foundation
 
-public protocol BlockAndMuteAPIv2 {
+open class BlockAndMuteAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/blocks/api-reference/get-users-blocking
-    func getBlockUsers(
+    public func getBlockUsers(
         _ request: GetUsersBlockingRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/blocks/api-reference/post-users-user_id-blocking
-    func blockUser(
+    public func blockUser(
         _ request: PostUsersBlockingRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/blocks/api-reference/delete-users-user_id-blocking
-    func unblockUser(
+    public func unblockUser(
         _ request: DeleteUsersBlockingRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/mutes/api-reference/get-users-muting
-    func getMuteUsers(
+    public func getMuteUsers(
         _ request: GetUsersMutingRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/mutes/api-reference/post-users-user_id-muting
-    func muteUser(
+    public func muteUser(
         _ request: PostUsersMutingRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/mutes/api-reference/delete-users-user_id-muting
-    func unmuteUser(
+    public func unmuteUser(
         _ request: DeleteUsersMutingRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: BlockAndMuteAPIv2 {
-
-    func getBlockUsers(_ request: GetUsersBlockingRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func blockUser(_ request: PostUsersBlockingRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func unblockUser(_ request: DeleteUsersBlockingRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getMuteUsers(_ request: GetUsersMutingRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func muteUser(_ request: PostUsersMutingRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func unmuteUser(_ request: DeleteUsersMutingRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/Bookmarks/BookmarksAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Bookmarks/BookmarksAPIv2.swift
@@ -1,34 +1,25 @@
 import Foundation
 
-public protocol BookmarksAPIv2 {
+open class BookmarksAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/bookmarks/api-reference/get-users-id-bookmarks
-    func getBookmarks(
+    public func getBookmarks(
         _ request: GetUsersBookmarksRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/bookmarks/api-reference/post-users-id-bookmarks
-    func createBookmark(
+    public func createBookmark(
         _ request: PostUsersBookmarksRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/bookmarks/api-reference/delete-users-id-bookmarks-tweet_id
-    func deleteBookmark(
+    public func deleteBookmark(
         _ request: DeleteUsersBookmarksRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: BookmarksAPIv2 {
-
-    func getBookmarks(_ request: GetUsersBookmarksRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func createBookmark(_ request: PostUsersBookmarksRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func deleteBookmark(_ request: DeleteUsersBookmarksRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/Compliance/ComplianceAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Compliance/ComplianceAPIv2.swift
@@ -1,34 +1,25 @@
 import Foundation
 
-public protocol ComplianceAPIv2 {
+open class ComplianceAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/compliance/batch-compliance/api-reference/get-compliance-jobs-id
-    func getComplianceJob(
+    public func getComplianceJob(
         _ request: GetComplianceJobRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/compliance/batch-compliance/api-reference/get-compliance-jobs
-    func getComplianceJobj(
+    public func getComplianceJobj(
         _ request: GetComplianceJobsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/compliance/batch-compliance/api-reference/post-compliance-jobs
-    func createComplianceJob(
+    public func createComplianceJob(
         _ request: PostComplianceJobsRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: ComplianceAPIv2 {
-
-    func getComplianceJob(_ request: GetComplianceJobRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getComplianceJobj(_ request: GetComplianceJobsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func createComplianceJob(_ request: PostComplianceJobsRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/Friendships/FriendshipsAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Friendships/FriendshipsAPIv2.swift
@@ -1,42 +1,31 @@
 import Foundation
 
-public protocol FriendshipsAPIv2 {
+open class FriendshipsAPIv2: TwitterAPIBase {
     /// https://developer.twitter.com/en/docs/twitter-api/users/follows/api-reference/get-users-id-following
-    func getFollowing(
+    public func getFollowing(
         _ request: GetUsersFollowingRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/follows/api-reference/get-users-id-followers
-    func getFollowers(
+    public func getFollowers(
         _ request: GetUsersFollowersRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/follows/api-reference/post-users-source_user_id-following
-    func follow(
+    public func follow(
         _ request: PostUsersFollowingRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/follows/api-reference/delete-users-source_id-following
-    func unfollow(
+    public func unfollow(
         _ request: DeleteUsersFollowingRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: FriendshipsAPIv2 {
-
-    func getFollowing(_ request: GetUsersFollowingRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getFollowers(_ request: GetUsersFollowersRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func follow(_ request: PostUsersFollowingRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func unfollow(_ request: DeleteUsersFollowingRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/Like/LikeAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Like/LikeAPIv2.swift
@@ -1,48 +1,29 @@
 import Foundation
 
-public protocol LikeAPIv2 {
+open class LikeAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/get-tweets-id-liking_users
-    func getLikingUsers(
-        _ request: GetTweetsLikingUsersRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/get-users-id-liked_tweets
-    func getLikedTweets(
-        _ request: GetUsersLikedTweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/post-users-id-likes
-    func postLike(
-        _ request: PostUsersLikesRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/delete-users-id-likes-tweet_id
-    func deleteLike(
-        _ request: DeleteUsersLikesRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: LikeAPIv2 {
     public func getLikingUsers(
         _ request: GetTweetsLikingUsersRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/get-users-id-liked_tweets
     public func getLikedTweets(
         _ request: GetUsersLikedTweetsRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/post-users-id-likes
     public func postLike(
         _ request: PostUsersLikesRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/delete-users-id-likes-tweet_id
     public func deleteLike(
         _ request: DeleteUsersLikesRequestV2
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv2/List/ListAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/List/ListAPIv2.swift
@@ -1,160 +1,123 @@
 import Foundation
 
-public protocol ListAPIv2 {
+open class ListAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-tweets/api-reference/get-lists-id-tweets
-    func getListTweets(
+    public func getListTweets(
         _ request: GetListsTweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-lookup/api-reference/get-lists-id
-    func getList(
+    public func getList(
         _ request: GetListRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-lookup/api-reference/get-users-id-owned_lists
-    func getLists(
+    public func getLists(
         _ request: GetUsersOwnedListsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-follows/api-reference/post-users-id-followed-lists
-    func followList(
+    public func followList(
         _ request: PostUsersFollowedListsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-follows/api-reference/delete-users-id-followed-lists-list_id
-    func unfollowList(
+    public func unfollowList(
         _ request: DeleteUsersFollowedListsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-follows/api-reference/get-lists-id-followers
-    func listFollowers(
+    public func listFollowers(
         _ request: GetListsFollowersRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-follows/api-reference/get-users-id-followed_lists
-    func followedLists(
+    public func followedLists(
         _ request: GetUsersFollowedListsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-members/api-reference/post-lists-id-members
-    func addListMember(
+    public func addListMember(
         _ request: PostListsMembersRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-members/api-reference/delete-lists-id-members-user_id
-    func removeListMember(
+    public func removeListMember(
         _ request: DeleteListsMembersRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-members/api-reference/get-users-id-list_memberships
-    func getListMemberships(
+    public func getListMemberships(
         _ request: GetUsersListMembershipsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/list-members/api-reference/get-lists-id-members
-    func getListMembers(
+    public func getListMembers(
         _ request: GetListsMembersRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/manage-lists/api-reference/post-lists
-    func createList(
+    public func createList(
         _ request: PostListsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/manage-lists/api-reference/put-lists-id
-    func updateList(
+    public func updateList(
         _ request: PutListRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/manage-lists/api-reference/delete-lists-id
-    func deleteList(
+    public func deleteList(
         _ request: DeleteListRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/pinned-lists/api-reference/get-users-id-pinned_lists
-    func pinnedList(
+    public func pinnedList(
         _ request: GetUsersPinnedListsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/pinned-lists/api-reference/post-users-id-pinned-lists
-    func pinList(
+    public func pinList(
         _ request: PostUsersPinnedListsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/lists/pinned-lists/api-reference/delete-users-id-pinned-lists-list_id
-    func unpinList(
+    public func unpinList(
         _ request: DeleteUsersPinnedListsRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: ListAPIv2 {
-
-    func getListTweets(_ request: GetListsTweetsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getList(_ request: GetListRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getLists(_ request: GetUsersOwnedListsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func followList(_ request: PostUsersFollowedListsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func unfollowList(_ request: DeleteUsersFollowedListsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func listFollowers(_ request: GetListsFollowersRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func followedLists(_ request: GetUsersFollowedListsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func addListMember(_ request: PostListsMembersRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func removeListMember(_ request: DeleteListsMembersRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getListMemberships(_ request: GetUsersListMembershipsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getListMembers(_ request: GetListsMembersRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func createList(_ request: PostListsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func updateList(_ request: PutListRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func deleteList(_ request: DeleteListRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func pinnedList(_ request: GetUsersPinnedListsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func pinList(_ request: PostUsersPinnedListsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func unpinList(_ request: DeleteUsersPinnedListsRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/Retweet/RetweetAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Retweet/RetweetAPIv2.swift
@@ -1,37 +1,22 @@
 import Foundation
 
-public protocol RetweetAPIv2 {
+open class RetweetAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/retweets/api-reference/get-tweets-id-retweeted_by
-    func getRetweetedBy(
-        _ request: GetTweetsRetweetedByRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/retweets/api-reference/post-users-id-retweets
-    func postRetweet(
-        _ request: PostUsersRetweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/retweets/api-reference/delete-users-id-retweets-tweet_id
-    func deleteRetweet(
-        _ request: DeleteUsersRetweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: RetweetAPIv2 {
-
     public func getRetweetedBy(
         _ request: GetTweetsRetweetedByRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/retweets/api-reference/post-users-id-retweets
     public func postRetweet(
         _ request: PostUsersRetweetsRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/retweets/api-reference/delete-users-id-retweets-tweet_id
     public func deleteRetweet(
         _ request: DeleteUsersRetweetsRequestV2
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/APIv2/Search/SearchAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Search/SearchAPIv2.swift
@@ -1,26 +1,19 @@
 import Foundation
 
-public protocol SearchAPIv2 {
+open class SearchAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-recent
-    func searchTweetsRecent(
+    public func searchTweetsRecent(
         _ request: GetTweetsSearchRecentRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-all
-    /// - Important: This endpoint is only available to those users who have been approved for Academic Research access.
-    func searchTweetsAll(
-        _ request: GetTweetsSearchAllRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: SearchAPIv2 {
-
-    func searchTweetsRecent(_ request: GetTweetsSearchRecentRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
-    func searchTweetsAll(_ request: GetTweetsSearchAllRequestV2) -> TwitterAPISessionJSONTask {
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-all
+    /// - Important: This endpoint is only available to those users who have been approved for Academic Research access.
+    public func searchTweetsAll(
+        _ request: GetTweetsSearchAllRequestV2
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/Spaces/SpacesAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Spaces/SpacesAPIv2.swift
@@ -1,61 +1,46 @@
 import Foundation
 
-public protocol SpacesAPIv2 {
+open class SpacesAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/spaces/lookup/api-reference/get-spaces-id
-    func getSpace(
+    public func getSpace(
         _ request: GetSpaceRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/spaces/lookup/api-reference/get-spaces
-    func getSpaces(
+    public func getSpaces(
         _ request: GetSpacesRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/spaces/lookup/api-reference/get-spaces-by-creator-ids
-    func getSpacesByCreators(
+    public func getSpacesByCreators(
         _ request: GetSpacesByCreatorIDsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/spaces/lookup/api-reference/get-spaces-id-buyers
-    func getSpacesBuyers(
+    public func getSpacesBuyers(
         _ request: GetSpacesBuyersRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/spaces/lookup/api-reference/get-spaces-id-tweets
-    func getSPacesTweets(
+    public func getSPacesTweets(
         _ request: GetSpacesTweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/spaces/search/api-reference/get-spaces-search
-    func searchSpaces(
+    public func searchSpaces(
         _ request: GetSpacesSearchRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: SpacesAPIv2 {
-
-    func getSpace(_ request: GetSpaceRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getSpaces(_ request: GetSpacesRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getSpacesByCreators(_ request: GetSpacesByCreatorIDsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getSpacesBuyers(_ request: GetSpacesBuyersRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getSPacesTweets(_ request: GetSpacesTweetsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func searchSpaces(_ request: GetSpacesSearchRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/Stream/StreamAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Stream/StreamAPIv2.swift
@@ -1,47 +1,32 @@
 import Foundation
 
-public protocol StreamAPIv2 {
+open class StreamAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/volume-streams/api-reference/get-tweets-sample-stream
-    func sampleStream(
+    public func sampleStream(
         _ request: GetTweetsSampleStreamRequestV2
-    ) -> TwitterAPISessionStreamTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream-rules
-    func getSearchStreamRules(
-        _ request: GetTweetsSearchStreamRulesRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/post-tweets-search-stream-rules#Validate
-    func postSearchStreamRules(
-        _ request: PostTweetsSearchStreamRulesRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream
-    func searchStream(
-        _ request: GetTweetsSearchStreamRequestV2
-    ) -> TwitterAPISessionStreamTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: StreamAPIv2 {
-
-    func sampleStream(_ request: GetTweetsSampleStreamRequestV2) -> TwitterAPISessionStreamTask {
+    ) -> TwitterAPISessionStreamTask {
         return session.send(streamRequest: request)
     }
 
-    func getSearchStreamRules(
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream-rules
+    public func getSearchStreamRules(
         _ request: GetTweetsSearchStreamRulesRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
-    func postSearchStreamRules(
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/post-tweets-search-stream-rules#Validate
+    public func postSearchStreamRules(
         _ request: PostTweetsSearchStreamRulesRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
-    func searchStream(_ request: GetTweetsSearchStreamRequestV2) -> TwitterAPISessionStreamTask {
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream
+    public func searchStream(
+        _ request: GetTweetsSearchStreamRequestV2
+    ) -> TwitterAPISessionStreamTask {
         return session.send(streamRequest: request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/Timeline/TimelineAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Timeline/TimelineAPIv2.swift
@@ -1,39 +1,24 @@
 import Foundation
 
-public protocol TimelineAPIv2 {
+open class TimelineAPIv2: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-tweets
-    func getUserTweets(
-        _ request: GetUsersTweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-mentions
-    func getUserMensions(
-        _ request: GetUsersMentionsRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// a.k.a Home Timeline
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-reverse-chronological
-    func getUserReverseChronological(
-        _ request: GetUsersTimelinesReverseChronologicalRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: TimelineAPIv2 {
-
     public func getUserTweets(
         _ request: GetUsersTweetsRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-mentions
     public func getUserMensions(
         _ request: GetUsersMentionsRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
-    func getUserReverseChronological(
+    /// a.k.a Home Timeline
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/timelines/api-reference/get-users-id-reverse-chronological
+    public func getUserReverseChronological(
         _ request: GetUsersTimelinesReverseChronologicalRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)

--- a/Sources/TwitterAPIKit/APIv2/Tweet/TweetAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Tweet/TweetAPIv2.swift
@@ -1,60 +1,45 @@
 import Foundation
 
-public protocol TweetAPIv2 {
+open class TweetAPIv2: TwitterAPIBase {
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference/get-tweets
-    func getTweets(
+    public func getTweets(
         _ request: GetTweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/lookup/api-reference/get-tweets-id
-    func getTweet(
+    public func getTweet(
         _ request: GetTweetRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/quote-tweets/api-reference/get-tweets-id-quote_tweets
-    func getQuoteTweets(
+    public func getQuoteTweets(
         _ request: GetTweetsQuoteTweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/delete-tweets-id
-    func deleteTweet(
+    public func deleteTweet(
         _ request: DeleteTweetRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets
-    func postTweet(
+    public func postTweet(
         _ request: PostTweetsRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/hide-replies/api-reference/put-tweets-id-hidden
-    func hideReply(
+    public func hideReply(
         _ request: PutTweetsHiddenRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: TweetAPIv2 {
-
-    public func getTweets(_ request: GetTweetsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    public func getTweet(_ request: GetTweetRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getQuoteTweets(_ request: GetTweetsQuoteTweetsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func deleteTweet(_ request: DeleteTweetRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func postTweet(_ request: PostTweetsRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func hideReply(_ request: PutTweetsHiddenRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/APIv2/TweetCount/TweetCountAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/TweetCount/TweetCountAPIv2.swift
@@ -1,26 +1,16 @@
 import Foundation
 
-public protocol TweetCountAPIv2 {
+open class TweetCountAPIv2: TwitterAPIBase {
     /// https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-recent
-    func getTweetCountRecent(
-        _ request: GetTweetsCountsRecentRequestV2
-    ) -> TwitterAPISessionJSONTask
-
-    /// https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-all
-    /// - Important: This endpoint is only available to those users who have been approved for Academic Research access.
-    func getTweetCountAll(
-        _ request: GetTweetsCountsAllRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: TweetCountAPIv2 {
-    func getTweetCountRecent(
+    public func getTweetCountRecent(
         _ request: GetTweetsCountsRecentRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 
-    func getTweetCountAll(
+    /// https://developer.twitter.com/en/docs/twitter-api/tweets/counts/api-reference/get-tweets-counts-all
+    /// - Important: This endpoint is only available to those users who have been approved for Academic Research access.
+    public func getTweetCountAll(
         _ request: GetTweetsCountsAllRequestV2
     ) -> TwitterAPISessionJSONTask {
         return session.send(request)

--- a/Sources/TwitterAPIKit/APIv2/TwitterAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/TwitterAPIv2.swift
@@ -2,55 +2,38 @@ import Foundation
 
 // https://developer.twitter.com/en/docs/api-reference-index
 
-public typealias TwitterAPIv2 =
-    TwitterAPIResourceV2
-    & BlockAndMuteAPIv2
-    & BookmarksAPIv2
-    & ComplianceAPIv2
-    & FriendshipsAPIv2
-    & LikeAPIv2
-    & ListAPIv2
-    & RetweetAPIv2
-    & SearchAPIv2
-    & SpacesAPIv2
-    & StreamAPIv2
-    & TimelineAPIv2
-    & TweetAPIv2
-    & TweetCountAPIv2
-    & UserAPIv2
+open class TwitterAPIv2 {
+    public let blockAndMute: BlockAndMuteAPIv2
+    public let bookmarks: BookmarksAPIv2
+    public let compliance: ComplianceAPIv2
+    public let friendships: FriendshipsAPIv2
+    public let like: LikeAPIv2
+    public let list: ListAPIv2
+    public let retweet: RetweetAPIv2
+    public let search: SearchAPIv2
+    public let spaces: SpacesAPIv2
+    public let stream: StreamAPIv2
+    public let timeline: TimelineAPIv2
+    public let tweet: TweetAPIv2
+    public let tweetCount: TweetCountAPIv2
+    public let user: UserAPIv2
 
-public protocol TwitterAPIResourceV2 {
-    var blockAndMute: BlockAndMuteAPIv2 { get }
-    var bookmarks: BookmarksAPIv2 { get }
-    var compliance: ComplianceAPIv2 { get }
-    var friendships: FriendshipsAPIv2 { get }
-    var like: LikeAPIv2 { get }
-    var list: ListAPIv2 { get }
-    var retweet: RetweetAPIv2 { get }
-    var search: SearchAPIv2 { get }
-    var spaces: SpacesAPIv2 { get }
-    var stream: StreamAPIv2 { get }
-    var timeline: TimelineAPIv2 { get }
-    var tweet: TweetAPIv2 { get }
-    var tweetCount: TweetCountAPIv2 { get }
-    var user: UserAPIv2 { get }
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: TwitterAPIResourceV2 {
-    var blockAndMute: BlockAndMuteAPIv2 { return self }
-    var bookmarks: BookmarksAPIv2 { return self }
-    var friendships: FriendshipsAPIv2 { return self }
-    var compliance: ComplianceAPIv2 { return self }
-    var like: LikeAPIv2 { return self }
-    var list: ListAPIv2 { return self }
-    var retweet: RetweetAPIv2 { return self }
-    var search: SearchAPIv2 { return self }
-    var spaces: SpacesAPIv2 { return self }
-    var stream: StreamAPIv2 { return self }
-    var timeline: TimelineAPIv2 { return self }
-    var tweet: TweetAPIv2 { return self }
-    var tweetCount: TweetCountAPIv2 { return self }
-    var user: UserAPIv2 { return self }
+    public init(session: TwitterAPISession) {
+        blockAndMute = .init(session: session)
+        bookmarks = .init(session: session)
+        compliance = .init(session: session)
+        friendships = .init(session: session)
+        like = .init(session: session)
+        list = .init(session: session)
+        retweet = .init(session: session)
+        search = .init(session: session)
+        spaces = .init(session: session)
+        stream = .init(session: session)
+        timeline = .init(session: session)
+        tweet = .init(session: session)
+        tweetCount = .init(session: session)
+        user = .init(session: session)
+    }
 }
 
 public protocol TwitterAPIv2RequestParameter {

--- a/Sources/TwitterAPIKit/APIv2/Users/UserAPIv2.swift
+++ b/Sources/TwitterAPIKit/APIv2/Users/UserAPIv2.swift
@@ -1,51 +1,38 @@
 import Foundation
 
-public protocol UserAPIv2 {
+open class UserAPIv2: TwitterAPIBase {
     /// https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-id
-    func getUser(
+    public func getUser(
         _ request: GetUserRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users
-    func getUsers(
+    public func getUsers(
         _ request: GetUsersRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-by-username-username
-    func getUserByUsername(
+    public func getUserByUsername(
         _ request: GetUsersByUsernameRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-by
-    func getUsersByUsernames(
+    public func getUsersByUsernames(
         _ request: GetUsersByRequestV2
-    ) -> TwitterAPISessionJSONTask
+    ) -> TwitterAPISessionJSONTask {
+        return session.send(request)
+    }
 
     /// https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me
-    func getMe(
+    public func getMe(
         _ request: GetUsersMeRequestV2
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAPIImplV2: UserAPIv2 {
-
-    func getUser(_ request: GetUserRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getUsers(_ request: GetUsersRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getUserByUsername(_ request: GetUsersByUsernameRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getUsersByUsernames(_ request: GetUsersByRequestV2) -> TwitterAPISessionJSONTask {
-        return session.send(request)
-    }
-
-    func getMe(_ request: GetUsersMeRequestV2) -> TwitterAPISessionJSONTask {
+    ) -> TwitterAPISessionJSONTask {
         return session.send(request)
     }
 }

--- a/Sources/TwitterAPIKit/AuthAPI/AuthAPI.swift
+++ b/Sources/TwitterAPIKit/AuthAPI/AuthAPI.swift
@@ -1,14 +1,12 @@
-public typealias TwitterAuthAPI =
-    TwitterAuthAPIResource
-    & OAuth10aAPI
-    & OAuth20API
+open class TwitterAuthAPI: TwitterAPIBase {
 
-public protocol TwitterAuthAPIResource {
-    var oauth10a: OAuth10aAPI { get }
-    var oauth20: OAuth20API { get }
-}
+    public let oauth10a: OAuth10aAPI
+    public var oauth20: OAuth20API
 
-extension TwitterAPIClient.TwitterAuthAPIImpl: TwitterAuthAPIResource {
-    var oauth10a: OAuth10aAPI { return self }
-    var oauth20: OAuth20API { return self }
+    public override init(session: TwitterAPISession) {
+        oauth10a = .init(session: session)
+        oauth20 = .init(session: session)
+
+        super.init(session: session)
+    }
 }

--- a/Sources/TwitterAPIKit/AuthAPI/AuthAPI.swift
+++ b/Sources/TwitterAPIKit/AuthAPI/AuthAPI.swift
@@ -1,12 +1,10 @@
-open class TwitterAuthAPI: TwitterAPIBase {
+open class TwitterAuthAPI {
 
     public let oauth10a: OAuth10aAPI
-    public var oauth20: OAuth20API
+    public let oauth20: OAuth20API
 
-    public override init(session: TwitterAPISession) {
+    public init(session: TwitterAPISession) {
         oauth10a = .init(session: session)
         oauth20 = .init(session: session)
-
-        super.init(session: session)
     }
 }

--- a/Sources/TwitterAPIKit/AuthAPI/OAuth10aAPI.swift
+++ b/Sources/TwitterAPIKit/AuthAPI/OAuth10aAPI.swift
@@ -1,46 +1,16 @@
 import Foundation
 
-public protocol OAuth10aAPI {
-    /// https://developer.twitter.com/en/docs/authentication/api-reference/request_token
-    func postOAuthRequestTokenData(
-        _ request: PostOAuthRequestTokenRequestV1
-    ) -> TwitterAPISessionDataTask
+open class OAuth10aAPI: TwitterAPIBase {
 
     /// https://developer.twitter.com/en/docs/authentication/api-reference/request_token
-    func postOAuthRequestToken(
-        _ request: PostOAuthRequestTokenRequestV1
-    ) -> TwitterAPISessionSpecializedTask<TwitterOAuthTokenV1>
-
-    /// Create https://developer.twitter.com/en/docs/authentication/api-reference/authorize URL.
-    func makeOAuthAuthorizeURL(_ request: GetOAuthAuthorizeRequestV1) -> URL?
-
-    /// Create https://developer.twitter.com/en/docs/authentication/api-reference/authenticate URL.
-    func makeOAuthAuthenticateURL(_ request: GetOAuthAuthenticateRequestV1) -> URL?
-
-    /// https://developer.twitter.com/en/docs/authentication/api-reference/access_token
-    func postOAuthAccessTokenData(
-        _ request: PostOAuthAccessTokenRequestV1
-    ) -> TwitterAPISessionDataTask
-
-    /// https://developer.twitter.com/en/docs/authentication/api-reference/access_token
-    func postOAuthAccessToken(
-        _ request: PostOAuthAccessTokenRequestV1
-    ) -> TwitterAPISessionSpecializedTask<TwitterOAuthAccessTokenV1>
-
-    /// https://developer.twitter.com/en/docs/authentication/api-reference/invalidate_access_token
-    func postInvalidateAccessToken(
-        _ request: PostOAuthInvalidateTokenRequestV1
-    ) -> TwitterAPISessionJSONTask
-}
-
-extension TwitterAPIClient.TwitterAuthAPIImpl: OAuth10aAPI {
     public func postOAuthRequestTokenData(
         _ request: PostOAuthRequestTokenRequestV1
     ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 
-    func postOAuthRequestToken(
+    /// https://developer.twitter.com/en/docs/authentication/api-reference/request_token
+    public func postOAuthRequestToken(
         _ request: PostOAuthRequestTokenRequestV1
     ) -> TwitterAPISessionSpecializedTask<TwitterOAuthTokenV1> {
         return session.send(request)
@@ -54,23 +24,27 @@ extension TwitterAPIClient.TwitterAuthAPIImpl: OAuth10aAPI {
             }
     }
 
+    /// Create https://developer.twitter.com/en/docs/authentication/api-reference/authorize URL.
     public func makeOAuthAuthorizeURL(_ request: GetOAuthAuthorizeRequestV1) -> URL? {
         // ignore exception
         return try? request.buildRequest(environment: session.environment).url
     }
 
+    /// Create https://developer.twitter.com/en/docs/authentication/api-reference/authenticate URL.
     public func makeOAuthAuthenticateURL(_ request: GetOAuthAuthenticateRequestV1) -> URL? {
         // ignore exception
         return try? request.buildRequest(environment: session.environment).url
     }
 
+    /// https://developer.twitter.com/en/docs/authentication/api-reference/access_token
     public func postOAuthAccessTokenData(
         _ request: PostOAuthAccessTokenRequestV1
     ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 
-    func postOAuthAccessToken(
+    /// https://developer.twitter.com/en/docs/authentication/api-reference/access_token
+    public func postOAuthAccessToken(
         _ request: PostOAuthAccessTokenRequestV1
     ) -> TwitterAPISessionSpecializedTask<TwitterOAuthAccessTokenV1> {
         return session.send(request)
@@ -84,6 +58,7 @@ extension TwitterAPIClient.TwitterAuthAPIImpl: OAuth10aAPI {
             }
     }
 
+    /// https://developer.twitter.com/en/docs/authentication/api-reference/invalidate_access_token
     public func postInvalidateAccessToken(
         _ request: PostOAuthInvalidateTokenRequestV1
     ) -> TwitterAPISessionJSONTask {

--- a/Sources/TwitterAPIKit/AuthAPI/OAuth20API.swift
+++ b/Sources/TwitterAPIKit/AuthAPI/OAuth20API.swift
@@ -1,65 +1,18 @@
 import Foundation
 
-public protocol OAuth20API {
+open class OAuth20API: TwitterAPIBase {
 
     // MARK: - OAuth 2.0 Bearer Token
 
     /// https://developer.twitter.com/en/docs/authentication/api-reference/token
-    func postOAuth2BearerTokenData(
-        _ request: PostOAuth2TokenRequestV1
-    ) -> TwitterAPISessionDataTask
-
-    /// https://developer.twitter.com/en/docs/authentication/api-reference/token
-    func postOAuth2BearerToken(
-        _ request: PostOAuth2TokenRequestV1
-    ) -> TwitterAPISessionSpecializedTask<TwitterOAuth2BearerToken>
-
-    /// https://developer.twitter.com/en/docs/authentication/api-reference/invalidate_bearer_token
-    ///
-    ///May not work. {"errors":[{"code":348,"message":"Client application is not permitted to to invalidate this token."}]}
-    /// https://twittercommunity.com/t/oauth2-invalidate-token-not-working-for-app-only-authentication-tokens/133108
-    /// https://twittercommunity.com/t/invalidate-bearer-client-application-not-permitted/162761
-    func postInvalidateOAuth2BearerToken(
-        _ request: PostOAuth2InvalidateTokenRequestV1
-    ) -> TwitterAPISessionJSONTask
-
-    // MARK: - OAuth 2.0 Authorization Code Flow with PKCE
-
-    /// Create OAuth 2.0  Authorize URL
-    func makeOAuth2AuthorizeURL(_ request: GetOAuth2AuthorizeRequestV1) -> URL?
-
-    func postOAuth2AccessTokenData(
-        _ request: PostOAuth2AccessTokenRequestV2
-    ) -> TwitterAPISessionDataTask
-
-    func postOAuth2AccessToken(
-        _ request: PostOAuth2AccessTokenRequestV2
-    ) -> TwitterAPISessionSpecializedTask<TwitterOAuth2AccessToken>
-
-    func postOAuth2RefreshTokenData(
-        _ request: PostOAuth2RefreshTokenRequestV2
-    ) -> TwitterAPISessionDataTask
-
-    func postOAuth2RefreshToken(
-        _ request: PostOAuth2RefreshTokenRequestV2
-    ) -> TwitterAPISessionSpecializedTask<TwitterOAuth2AccessToken>
-
-    func postOAuth2RevokeToken(
-        _ request: PostOAuth2RevokeTokenRequestV2
-    ) -> TwitterAPISessionDataTask
-}
-
-extension TwitterAPIClient.TwitterAuthAPIImpl: OAuth20API {
-
-    // MARK: - OAuth 2.0 Bearer Token
-
     public func postOAuth2BearerTokenData(
         _ request: PostOAuth2TokenRequestV1
     ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 
-    func postOAuth2BearerToken(
+    /// https://developer.twitter.com/en/docs/authentication/api-reference/token
+    public func postOAuth2BearerToken(
         _ request: PostOAuth2TokenRequestV1
     ) -> TwitterAPISessionSpecializedTask<TwitterOAuth2BearerToken> {
         return session.send(request)
@@ -79,6 +32,11 @@ extension TwitterAPIClient.TwitterAuthAPIImpl: OAuth20API {
             }
     }
 
+    /// https://developer.twitter.com/en/docs/authentication/api-reference/invalidate_bearer_token
+    ///
+    ///May not work. {"errors":[{"code":348,"message":"Client application is not permitted to to invalidate this token."}]}
+    /// https://twittercommunity.com/t/oauth2-invalidate-token-not-working-for-app-only-authentication-tokens/133108
+    /// https://twittercommunity.com/t/invalidate-bearer-client-application-not-permitted/162761
     public func postInvalidateOAuth2BearerToken(
         _ request: PostOAuth2InvalidateTokenRequestV1
     ) -> TwitterAPISessionJSONTask {
@@ -87,6 +45,7 @@ extension TwitterAPIClient.TwitterAuthAPIImpl: OAuth20API {
 
     // MARK: - OAuth 2.0 Authorization Code Flow with PKCE
 
+    /// Create OAuth 2.0  Authorize URL
     public func makeOAuth2AuthorizeURL(_ request: GetOAuth2AuthorizeRequestV1) -> URL? {
         return try? request.buildRequest(environment: session.environment).url
     }
@@ -97,27 +56,28 @@ extension TwitterAPIClient.TwitterAuthAPIImpl: OAuth20API {
         return session.send(request)
     }
 
-    func postOAuth2AccessToken(
+    public func postOAuth2AccessToken(
         _ request: PostOAuth2AccessTokenRequestV2
     ) -> TwitterAPISessionSpecializedTask<TwitterOAuth2AccessToken> {
         return postOAuth2AccessTokenData(request)
             .specialized { try TwitterOAuth2AccessToken.fromResponse(data: $0) }
     }
 
-    func postOAuth2RefreshTokenData(
+    public func postOAuth2RefreshTokenData(
         _ request: PostOAuth2RefreshTokenRequestV2
     ) -> TwitterAPISessionDataTask {
         return session.send(request)
     }
 
-    func postOAuth2RefreshToken(_ request: PostOAuth2RefreshTokenRequestV2) -> TwitterAPISessionSpecializedTask<
-        TwitterOAuth2AccessToken
-    > {
+    public func postOAuth2RefreshToken(
+        _ request: PostOAuth2RefreshTokenRequestV2
+    ) -> TwitterAPISessionSpecializedTask<TwitterOAuth2AccessToken> {
         return postOAuth2RefreshTokenData(request)
             .specialized { try TwitterOAuth2AccessToken.fromResponse(data: $0) }
+
     }
 
-    func postOAuth2RevokeToken(
+    public func postOAuth2RevokeToken(
         _ request: PostOAuth2RevokeTokenRequestV2
     ) -> TwitterAPISessionDataTask {
         return session.send(request)

--- a/Sources/TwitterAPIKit/TwitterAPI+Flat.generated.swift
+++ b/Sources/TwitterAPIKit/TwitterAPI+Flat.generated.swift
@@ -1,0 +1,680 @@
+// Generated using Sourcery 1.8.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swift-format-ignore-file
+import Foundation
+
+extension TwitterAuthAPI {
+
+    // MARK: - OAuth10aAPI
+
+    public func postOAuthRequestTokenData(_ request: PostOAuthRequestTokenRequestV1) -> TwitterAPISessionDataTask {
+        return oauth10a.postOAuthRequestTokenData(request)
+    }
+    public func postOAuthRequestToken(_ request: PostOAuthRequestTokenRequestV1) -> TwitterAPISessionSpecializedTask<TwitterOAuthTokenV1> {
+        return oauth10a.postOAuthRequestToken(request)
+    }
+    public func makeOAuthAuthorizeURL(_ request: GetOAuthAuthorizeRequestV1) -> URL? {
+        return oauth10a.makeOAuthAuthorizeURL(request)
+    }
+    public func makeOAuthAuthenticateURL(_ request: GetOAuthAuthenticateRequestV1) -> URL? {
+        return oauth10a.makeOAuthAuthenticateURL(request)
+    }
+    public func postOAuthAccessTokenData(_ request: PostOAuthAccessTokenRequestV1) -> TwitterAPISessionDataTask {
+        return oauth10a.postOAuthAccessTokenData(request)
+    }
+    public func postOAuthAccessToken(_ request: PostOAuthAccessTokenRequestV1) -> TwitterAPISessionSpecializedTask<TwitterOAuthAccessTokenV1> {
+        return oauth10a.postOAuthAccessToken(request)
+    }
+    public func postInvalidateAccessToken(_ request: PostOAuthInvalidateTokenRequestV1) -> TwitterAPISessionJSONTask {
+        return oauth10a.postInvalidateAccessToken(request)
+    }
+
+    // MARK: - OAuth20API
+
+    public func postOAuth2BearerTokenData(_ request: PostOAuth2TokenRequestV1) -> TwitterAPISessionDataTask {
+        return oauth20.postOAuth2BearerTokenData(request)
+    }
+    public func postOAuth2BearerToken(_ request: PostOAuth2TokenRequestV1) -> TwitterAPISessionSpecializedTask<TwitterOAuth2BearerToken> {
+        return oauth20.postOAuth2BearerToken(request)
+    }
+    public func postInvalidateOAuth2BearerToken(_ request: PostOAuth2InvalidateTokenRequestV1) -> TwitterAPISessionJSONTask {
+        return oauth20.postInvalidateOAuth2BearerToken(request)
+    }
+    public func makeOAuth2AuthorizeURL(_ request: GetOAuth2AuthorizeRequestV1) -> URL? {
+        return oauth20.makeOAuth2AuthorizeURL(request)
+    }
+    public func postOAuth2AccessTokenData(_ request: PostOAuth2AccessTokenRequestV2) -> TwitterAPISessionDataTask {
+        return oauth20.postOAuth2AccessTokenData(request)
+    }
+    public func postOAuth2AccessToken(_ request: PostOAuth2AccessTokenRequestV2) -> TwitterAPISessionSpecializedTask<TwitterOAuth2AccessToken> {
+        return oauth20.postOAuth2AccessToken(request)
+    }
+    public func postOAuth2RefreshTokenData(_ request: PostOAuth2RefreshTokenRequestV2) -> TwitterAPISessionDataTask {
+        return oauth20.postOAuth2RefreshTokenData(request)
+    }
+    public func postOAuth2RefreshToken(_ request: PostOAuth2RefreshTokenRequestV2) -> TwitterAPISessionSpecializedTask<TwitterOAuth2AccessToken> {
+        return oauth20.postOAuth2RefreshToken(request)
+    }
+    public func postOAuth2RevokeToken(_ request: PostOAuth2RevokeTokenRequestV2) -> TwitterAPISessionDataTask {
+        return oauth20.postOAuth2RevokeToken(request)
+    }
+}
+
+extension TwitterAPIv1 {
+
+    // MARK: - AccountAPIv1
+
+    public func getAccountSetting(_ request: GetAccountSettingsRequestV1) -> TwitterAPISessionJSONTask {
+        return account.getAccountSetting(request)
+    }
+    public func getAccountVerify(_ request: GetAccountVerifyCredentialsRequestV1) -> TwitterAPISessionJSONTask {
+        return account.getAccountVerify(request)
+    }
+    public func postRemoveProfileBanner(_ request: PostAccountRemoveProfileBannerRequestV1) -> TwitterAPISessionJSONTask {
+        return account.postRemoveProfileBanner(request)
+    }
+    public func postAccountSettings(_ request: PostAccountSettingsRequestV1) -> TwitterAPISessionJSONTask {
+        return account.postAccountSettings(request)
+    }
+    public func postAccountProfile(_ request: PostAccountUpdateProfileRequestV1) -> TwitterAPISessionJSONTask {
+        return account.postAccountProfile(request)
+    }
+    public func postProfileBanner(_ request: PostAccountUpdateProfileBannerRequestV1) -> TwitterAPISessionDataTask {
+        return account.postProfileBanner(request)
+    }
+    public func postProfileImage(_ request: PostAccountUpdateProfileImageRequestV1) -> TwitterAPISessionJSONTask {
+        return account.postProfileImage(request)
+    }
+
+    // MARK: - ApplicationAPIv1
+
+    public func getRateLimit(_ request: GetApplicationRateLimitStatusRequestV1) -> TwitterAPISessionJSONTask {
+        return application.getRateLimit(request)
+    }
+
+    // MARK: - BlockAndMuteAPIv1
+
+    public func getBlockIDs(_ request: GetBlocksIDsRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.getBlockIDs(request)
+    }
+    public func getBlockUsers(_ request: GetBlocksListRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.getBlockUsers(request)
+    }
+    public func getMuteIDs(_ request: GetMutesUsersIDsRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.getMuteIDs(request)
+    }
+    public func getMuteUsers(_ request: GetMutesUsersListRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.getMuteUsers(request)
+    }
+    public func postBlockUser(_ request: PostBlocksCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.postBlockUser(request)
+    }
+    public func postUnblockUser(_ request: PostBlocksDestroyRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.postUnblockUser(request)
+    }
+    public func postMuteUser(_ request: PostMutesUsersCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.postMuteUser(request)
+    }
+    public func postUnmuteUser(_ request: PostMutesUsersDestroyRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.postUnmuteUser(request)
+    }
+    public func postReportSpam(_ request: PostUsersReportSpamRequestV1) -> TwitterAPISessionJSONTask {
+        return blockAndMute.postReportSpam(request)
+    }
+
+    // MARK: - CollectionAPIv1
+
+    public func getCollectionEntries(_ request: GetCollectionsEntriesRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.getCollectionEntries(request)
+    }
+    public func getCollections(_ request: GetCollectionsListRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.getCollections(request)
+    }
+    public func getCollection(_ request: GetCollectionsShowRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.getCollection(request)
+    }
+    public func postCreateCollection(_ request: PostCollectionsCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.postCreateCollection(request)
+    }
+    public func postDestroyCollection(_ request: PostCollectionsDestroyRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.postDestroyCollection(request)
+    }
+    public func postCollectionAddEntry(_ request: PostCollectionsEntriesAddRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.postCollectionAddEntry(request)
+    }
+    public func postCollectionCurate(_ request: PostCollectionsEntriesCurateRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.postCollectionCurate(request)
+    }
+    public func postCollectionMoveEntry(_ request: PostCollectionsEntriesMoveRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.postCollectionMoveEntry(request)
+    }
+    public func postCollectionRemoveEntry(_ request: PostCollectionsEntriesRemoveRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.postCollectionRemoveEntry(request)
+    }
+    public func postCollectionUpdate(_ request: PostCollectionsUpdateRequestV1) -> TwitterAPISessionJSONTask {
+        return collection.postCollectionUpdate(request)
+    }
+
+    // MARK: - DirectMessageAPIv1
+
+    public func postDirectMessage(_ request: PostDirectMessageRequestV1) -> TwitterAPISessionJSONTask {
+        return directMessage.postDirectMessage(request)
+    }
+    public func deleteDirectMessage(_ request: DeleteDirectMessageRequestV1) -> TwitterAPISessionDataTask {
+        return directMessage.deleteDirectMessage(request)
+    }
+    public func getDirectMessage(_ request: GetDirectMessageRequestV1) -> TwitterAPISessionJSONTask {
+        return directMessage.getDirectMessage(request)
+    }
+    public func getDirectMessageList(_ request: GetDirectMessageListRequestV1) -> TwitterAPISessionJSONTask {
+        return directMessage.getDirectMessageList(request)
+    }
+    public func postDirectMessageMarkRead(_ request: PostDirectMessagesMarkReadRequestV1) -> TwitterAPISessionDataTask {
+        return directMessage.postDirectMessageMarkRead(request)
+    }
+    public func postDirectMessageTypingIndicator(_ request: PostDirectMessagesIndicateTypingRequestV1) -> TwitterAPISessionDataTask {
+        return directMessage.postDirectMessageTypingIndicator(request)
+    }
+
+    // MARK: - FavoriteAPIv1
+
+    public func postFavorite(_ request: PostFavoriteRequestV1) -> TwitterAPISessionJSONTask {
+        return favorite.postFavorite(request)
+    }
+    public func postUnFavorite(_ request: PostUnFavoriteRequestV1) -> TwitterAPISessionJSONTask {
+        return favorite.postUnFavorite(request)
+    }
+    public func getFavorites(_ request: GetFavoritesRequestV1) -> TwitterAPISessionJSONTask {
+        return favorite.getFavorites(request)
+    }
+
+    // MARK: - FriendshipsAPIv1
+
+    public func getFollowerIDs(_ request: GetFollowersIDsRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFollowerIDs(request)
+    }
+    public func getFollowers(_ request: GetFollowersListRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFollowers(request)
+    }
+    public func getFriendIDs(_ request: GetFriendsIDsRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFriendIDs(request)
+    }
+    public func getFriends(_ request: GetFriendsListRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFriends(request)
+    }
+    public func getFriendshipsIncoming(_ request: GetFriendshipsIncomingRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFriendshipsIncoming(request)
+    }
+    public func getFriendshipsLookup(_ request: GetFriendshipsLookupRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFriendshipsLookup(request)
+    }
+    public func getFriendshipsNoRetweetsIDs(_ request: GetFriendshipsNoRetweetsIDsRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFriendshipsNoRetweetsIDs(request)
+    }
+    public func getFriendshipsOutgoing(_ request: GetFriendshipsOutgoingRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFriendshipsOutgoing(request)
+    }
+    public func getFriendships(_ request: GetFriendshipsShowRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.getFriendships(request)
+    }
+    public func postFollowUser(_ request: PostFriendshipsCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.postFollowUser(request)
+    }
+    public func postUnfollowUser(_ request: PostFriendshipsDestroyRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.postUnfollowUser(request)
+    }
+    public func postFriendshipsUpdate(_ request: PostFriendshipsUpdateRequestV1) -> TwitterAPISessionJSONTask {
+        return friendships.postFriendshipsUpdate(request)
+    }
+
+    // MARK: - GeoAPIv1
+
+    public func getReverseGeocode(_ request: GetGeoReverseGeocodeRequestV1) -> TwitterAPISessionJSONTask {
+        return geo.getReverseGeocode(request)
+    }
+    public func getGeoPlace(_ request: GetGeoPlaceIDRequestV1) -> TwitterAPISessionJSONTask {
+        return geo.getGeoPlace(request)
+    }
+    public func searchGeo(_ request: GetGeoSearchRequestV1) -> TwitterAPISessionJSONTask {
+        return geo.searchGeo(request)
+    }
+
+    // MARK: - HelpAPIv1
+
+    public func getSupportedLanguages(_ request: GetHelpLanguagesRequestV1) -> TwitterAPISessionJSONTask {
+        return help.getSupportedLanguages(request)
+    }
+
+    // MARK: - ListAPIv1
+
+    public func getLists(_ request: GetListsListRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getLists(request)
+    }
+    public func getListMembers(_ request: GetListsMembersRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getListMembers(request)
+    }
+    public func getListMember(_ request: GetListsMembersShowRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getListMember(request)
+    }
+    public func getListMemberships(_ request: GetListsMembershipsRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getListMemberships(request)
+    }
+    public func getListOwnerships(_ request: GetListsOwnershipsRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getListOwnerships(request)
+    }
+    public func getList(_ request: GetListsShowRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getList(request)
+    }
+    public func getListStatuses(_ request: GetListsStatusesRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getListStatuses(request)
+    }
+    public func getListSubscribers(_ request: GetListsSubscribersRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getListSubscribers(request)
+    }
+    public func getListSubscriber(_ request: GetListsSubscribersShowRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getListSubscriber(request)
+    }
+    public func getListSubscriptions(_ request: GetListsSubscriptionsRequestV1) -> TwitterAPISessionJSONTask {
+        return list.getListSubscriptions(request)
+    }
+    public func postCreateList(_ request: PostListsCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postCreateList(request)
+    }
+    public func postDestroyList(_ request: PostListsDestroyRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postDestroyList(request)
+    }
+    public func postAddListMember(_ request: PostListsMembersCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postAddListMember(request)
+    }
+    public func postAddListMembers(_ request: PostListsMembersCreateAllRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postAddListMembers(request)
+    }
+    public func postRemoveListMember(_ request: PostListsMembersDestroyRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postRemoveListMember(request)
+    }
+    public func postRemoveListMembers(_ request: PostListsMembersDestroyAllRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postRemoveListMembers(request)
+    }
+    public func postSubscribeList(_ request: PostListsSubscribersCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postSubscribeList(request)
+    }
+    public func postUnsubscribeList(_ request: PostListsSubscribersDestroyRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postUnsubscribeList(request)
+    }
+    public func postUpdateList(_ request: PostListsUpdateRequestV1) -> TwitterAPISessionJSONTask {
+        return list.postUpdateList(request)
+    }
+
+    // MARK: - MediaAPIv1
+
+    public func getUploadMediaStatus(_ request: GetUploadMediaStatusRequestV1) -> TwitterAPISessionJSONTask {
+        return media.getUploadMediaStatus(request)
+    }
+    public func uploadMediaInit(_ request: UploadMediaInitRequestV1) -> TwitterAPISessionJSONTask {
+        return media.uploadMediaInit(request)
+    }
+    public func uploadMediaAppend(_ request: UploadMediaAppendRequestV1) -> TwitterAPISessionJSONTask {
+        return media.uploadMediaAppend(request)
+    }
+    public func uploadMediaAppendSplitChunks(_ request: UploadMediaAppendRequestV1, maxBytes: Int = 5_242_880) -> [TwitterAPISessionSpecializedTask<String /* mediaID */>] {
+        return media.uploadMediaAppendSplitChunks(request, maxBytes: maxBytes)
+    }
+    public func uploadMediaFinalize(_ request: UploadMediaFinalizeRequestV1) -> TwitterAPISessionJSONTask {
+        return media.uploadMediaFinalize(request)
+    }
+    public func uploadMedia(_ parameters: UploadMediaRequestParameters, completionHandler: @escaping (TwitterAPIResponse<String>) -> Void) {
+        media.uploadMedia(parameters, completionHandler: completionHandler)
+    }
+    public func waitMediaProcessing(mediaID: String, initialWaitSec: Int, completionHandler: @escaping (TwitterAPIResponse<TwitterAPIClient.UploadMediaStatusResponse>) -> Void) {
+        media.waitMediaProcessing(mediaID: mediaID, initialWaitSec: initialWaitSec, completionHandler: completionHandler)
+    }
+    public func waitMediaProcessing(mediaID: String, completionHandler: @escaping (TwitterAPIResponse<TwitterAPIClient.UploadMediaStatusResponse>) -> Void) {
+        media.waitMediaProcessing(mediaID: mediaID, completionHandler: completionHandler)
+    }
+    public func createMediaMetadata(_ request: PostMediaMetadataCreateRequestV1) -> TwitterAPISessionDataTask {
+        return media.createMediaMetadata(request)
+    }
+    public func createSubtitle(_ request: PostMediaSubtitlesCreateRequestV1) -> TwitterAPISessionDataTask {
+        return media.createSubtitle(request)
+    }
+    public func deleteSubtitle(_ request: PostMediaSubtitlesDeleteRequestV1) -> TwitterAPISessionDataTask {
+        return media.deleteSubtitle(request)
+    }
+
+    // MARK: - RetweetAPIv1
+
+    public func postRetweet(_ request: PostRetweetRequestV1) -> TwitterAPISessionJSONTask {
+        return retweet.postRetweet(request)
+    }
+    public func postUnRetweet(_ request: PostUnRetweetRequestV1) -> TwitterAPISessionJSONTask {
+        return retweet.postUnRetweet(request)
+    }
+    public func getRetweets(_ request: GetRetweetsRequestV1) -> TwitterAPISessionJSONTask {
+        return retweet.getRetweets(request)
+    }
+    public func getRetweetsOfMe(_ request: GetRetweetsOfMeRequestV1) -> TwitterAPISessionJSONTask {
+        return retweet.getRetweetsOfMe(request)
+    }
+    public func getRetweeters(_ request: GetRetweetersRequestV1) -> TwitterAPISessionJSONTask {
+        return retweet.getRetweeters(request)
+    }
+
+    // MARK: - SearchAPIv1
+
+    public func searchTweets(_ request: GetSearchTweetsRequestV1) -> TwitterAPISessionJSONTask {
+        return search.searchTweets(request)
+    }
+    public func getSavedSearches(_ request: GetSavedSearchesListRequestV1) -> TwitterAPISessionJSONTask {
+        return search.getSavedSearches(request)
+    }
+    public func postCreateSavedSearch(_ request: PostSavedSearchesCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return search.postCreateSavedSearch(request)
+    }
+    public func postDestroySavedSearch(_ request: PostSavedSearchesCreateRequestV1) -> TwitterAPISessionJSONTask {
+        return search.postDestroySavedSearch(request)
+    }
+
+    // MARK: - TimelineAPIv1
+
+    public func getHomeTimeline(_ request: GetStatusesHomeTimelineRequestV1) -> TwitterAPISessionJSONTask {
+        return timeline.getHomeTimeline(request)
+    }
+    public func getMentionsTimeline(_ request: GetStatusesMentionsTimelineRequestV1) -> TwitterAPISessionJSONTask {
+        return timeline.getMentionsTimeline(request)
+    }
+    public func getUserTimeline(_ request: GetStatusesUserTimelineRequestV1) -> TwitterAPISessionJSONTask {
+        return timeline.getUserTimeline(request)
+    }
+
+    // MARK: - TrendAPIv1
+
+    public func getTrendsAvailable(_ request: GetTrendsAvailableRequestV1) -> TwitterAPISessionJSONTask {
+        return trend.getTrendsAvailable(request)
+    }
+    public func getTrendsClosest(_ request: GetTrendsClosestRequestV1) -> TwitterAPISessionJSONTask {
+        return trend.getTrendsClosest(request)
+    }
+    public func getTrends(_ request: GetTrendsPlaceRequestV1) -> TwitterAPISessionJSONTask {
+        return trend.getTrends(request)
+    }
+
+    // MARK: - TweetAPIv1
+
+    public func postUpdateStatus(_ request: PostStatusesUpdateRequestV1) -> TwitterAPISessionJSONTask {
+        return tweet.postUpdateStatus(request)
+    }
+    public func postDestroyStatus(_ request: PostStatusesDestroyRequestV1) -> TwitterAPISessionJSONTask {
+        return tweet.postDestroyStatus(request)
+    }
+    public func getShowStatus(_ request: GetStatusesShowRequestV1) -> TwitterAPISessionJSONTask {
+        return tweet.getShowStatus(request)
+    }
+    public func getLookupStatuses(_ request: GetStatusesLookupRequestV1) -> TwitterAPISessionJSONTask {
+        return tweet.getLookupStatuses(request)
+    }
+
+    // MARK: - UserAPIv1
+
+    public func getUsers(_ request: GetUsersLookupRequestV1) -> TwitterAPISessionJSONTask {
+        return user.getUsers(request)
+    }
+    public func getUser(_ request: GetUsersShowRequestV1) -> TwitterAPISessionJSONTask {
+        return user.getUser(request)
+    }
+    public func searchUser(_ request: GetUsersShowRequestV1) -> TwitterAPISessionJSONTask {
+        return user.searchUser(request)
+    }
+    public func getUserProfileBanner(_ request: GetUsersProfileBannerRequestV1) -> TwitterAPISessionJSONTask {
+        return user.getUserProfileBanner(request)
+    }
+}
+
+extension TwitterAPIv2 {
+
+    // MARK: - BlockAndMuteAPIv2
+
+    public func getBlockUsers(_ request: GetUsersBlockingRequestV2) -> TwitterAPISessionJSONTask {
+        return blockAndMute.getBlockUsers(request)
+    }
+    public func blockUser(_ request: PostUsersBlockingRequestV2) -> TwitterAPISessionJSONTask {
+        return blockAndMute.blockUser(request)
+    }
+    public func unblockUser(_ request: DeleteUsersBlockingRequestV2) -> TwitterAPISessionJSONTask {
+        return blockAndMute.unblockUser(request)
+    }
+    public func getMuteUsers(_ request: GetUsersMutingRequestV2) -> TwitterAPISessionJSONTask {
+        return blockAndMute.getMuteUsers(request)
+    }
+    public func muteUser(_ request: PostUsersMutingRequestV2) -> TwitterAPISessionJSONTask {
+        return blockAndMute.muteUser(request)
+    }
+    public func unmuteUser(_ request: DeleteUsersMutingRequestV2) -> TwitterAPISessionJSONTask {
+        return blockAndMute.unmuteUser(request)
+    }
+
+    // MARK: - BookmarksAPIv2
+
+    public func getBookmarks(_ request: GetUsersBookmarksRequestV2) -> TwitterAPISessionJSONTask {
+        return bookmarks.getBookmarks(request)
+    }
+    public func createBookmark(_ request: PostUsersBookmarksRequestV2) -> TwitterAPISessionJSONTask {
+        return bookmarks.createBookmark(request)
+    }
+    public func deleteBookmark(_ request: DeleteUsersBookmarksRequestV2) -> TwitterAPISessionJSONTask {
+        return bookmarks.deleteBookmark(request)
+    }
+
+    // MARK: - ComplianceAPIv2
+
+    public func getComplianceJob(_ request: GetComplianceJobRequestV2) -> TwitterAPISessionJSONTask {
+        return compliance.getComplianceJob(request)
+    }
+    public func getComplianceJobj(_ request: GetComplianceJobsRequestV2) -> TwitterAPISessionJSONTask {
+        return compliance.getComplianceJobj(request)
+    }
+    public func createComplianceJob(_ request: PostComplianceJobsRequestV2) -> TwitterAPISessionJSONTask {
+        return compliance.createComplianceJob(request)
+    }
+
+    // MARK: - FriendshipsAPIv2
+
+    public func getFollowing(_ request: GetUsersFollowingRequestV2) -> TwitterAPISessionJSONTask {
+        return friendships.getFollowing(request)
+    }
+    public func getFollowers(_ request: GetUsersFollowersRequestV2) -> TwitterAPISessionJSONTask {
+        return friendships.getFollowers(request)
+    }
+    public func follow(_ request: PostUsersFollowingRequestV2) -> TwitterAPISessionJSONTask {
+        return friendships.follow(request)
+    }
+    public func unfollow(_ request: DeleteUsersFollowingRequestV2) -> TwitterAPISessionJSONTask {
+        return friendships.unfollow(request)
+    }
+
+    // MARK: - LikeAPIv2
+
+    public func getLikingUsers(_ request: GetTweetsLikingUsersRequestV2) -> TwitterAPISessionJSONTask {
+        return like.getLikingUsers(request)
+    }
+    public func getLikedTweets(_ request: GetUsersLikedTweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return like.getLikedTweets(request)
+    }
+    public func postLike(_ request: PostUsersLikesRequestV2) -> TwitterAPISessionJSONTask {
+        return like.postLike(request)
+    }
+    public func deleteLike(_ request: DeleteUsersLikesRequestV2) -> TwitterAPISessionJSONTask {
+        return like.deleteLike(request)
+    }
+
+    // MARK: - ListAPIv2
+
+    public func getListTweets(_ request: GetListsTweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.getListTweets(request)
+    }
+    public func getList(_ request: GetListRequestV2) -> TwitterAPISessionJSONTask {
+        return list.getList(request)
+    }
+    public func getLists(_ request: GetUsersOwnedListsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.getLists(request)
+    }
+    public func followList(_ request: PostUsersFollowedListsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.followList(request)
+    }
+    public func unfollowList(_ request: DeleteUsersFollowedListsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.unfollowList(request)
+    }
+    public func listFollowers(_ request: GetListsFollowersRequestV2) -> TwitterAPISessionJSONTask {
+        return list.listFollowers(request)
+    }
+    public func followedLists(_ request: GetUsersFollowedListsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.followedLists(request)
+    }
+    public func addListMember(_ request: PostListsMembersRequestV2) -> TwitterAPISessionJSONTask {
+        return list.addListMember(request)
+    }
+    public func removeListMember(_ request: DeleteListsMembersRequestV2) -> TwitterAPISessionJSONTask {
+        return list.removeListMember(request)
+    }
+    public func getListMemberships(_ request: GetUsersListMembershipsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.getListMemberships(request)
+    }
+    public func getListMembers(_ request: GetListsMembersRequestV2) -> TwitterAPISessionJSONTask {
+        return list.getListMembers(request)
+    }
+    public func createList(_ request: PostListsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.createList(request)
+    }
+    public func updateList(_ request: PutListRequestV2) -> TwitterAPISessionJSONTask {
+        return list.updateList(request)
+    }
+    public func deleteList(_ request: DeleteListRequestV2) -> TwitterAPISessionJSONTask {
+        return list.deleteList(request)
+    }
+    public func pinnedList(_ request: GetUsersPinnedListsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.pinnedList(request)
+    }
+    public func pinList(_ request: PostUsersPinnedListsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.pinList(request)
+    }
+    public func unpinList(_ request: DeleteUsersPinnedListsRequestV2) -> TwitterAPISessionJSONTask {
+        return list.unpinList(request)
+    }
+
+    // MARK: - RetweetAPIv2
+
+    public func getRetweetedBy(_ request: GetTweetsRetweetedByRequestV2) -> TwitterAPISessionJSONTask {
+        return retweet.getRetweetedBy(request)
+    }
+    public func postRetweet(_ request: PostUsersRetweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return retweet.postRetweet(request)
+    }
+    public func deleteRetweet(_ request: DeleteUsersRetweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return retweet.deleteRetweet(request)
+    }
+
+    // MARK: - SearchAPIv2
+
+    public func searchTweetsRecent(_ request: GetTweetsSearchRecentRequestV2) -> TwitterAPISessionJSONTask {
+        return search.searchTweetsRecent(request)
+    }
+    public func searchTweetsAll(_ request: GetTweetsSearchAllRequestV2) -> TwitterAPISessionJSONTask {
+        return search.searchTweetsAll(request)
+    }
+
+    // MARK: - SpacesAPIv2
+
+    public func getSpace(_ request: GetSpaceRequestV2) -> TwitterAPISessionJSONTask {
+        return spaces.getSpace(request)
+    }
+    public func getSpaces(_ request: GetSpacesRequestV2) -> TwitterAPISessionJSONTask {
+        return spaces.getSpaces(request)
+    }
+    public func getSpacesByCreators(_ request: GetSpacesByCreatorIDsRequestV2) -> TwitterAPISessionJSONTask {
+        return spaces.getSpacesByCreators(request)
+    }
+    public func getSpacesBuyers(_ request: GetSpacesBuyersRequestV2) -> TwitterAPISessionJSONTask {
+        return spaces.getSpacesBuyers(request)
+    }
+    public func getSPacesTweets(_ request: GetSpacesTweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return spaces.getSPacesTweets(request)
+    }
+    public func searchSpaces(_ request: GetSpacesSearchRequestV2) -> TwitterAPISessionJSONTask {
+        return spaces.searchSpaces(request)
+    }
+
+    // MARK: - StreamAPIv2
+
+    public func sampleStream(_ request: GetTweetsSampleStreamRequestV2) -> TwitterAPISessionStreamTask {
+        return stream.sampleStream(request)
+    }
+    public func getSearchStreamRules(_ request: GetTweetsSearchStreamRulesRequestV2) -> TwitterAPISessionJSONTask {
+        return stream.getSearchStreamRules(request)
+    }
+    public func postSearchStreamRules(_ request: PostTweetsSearchStreamRulesRequestV2) -> TwitterAPISessionJSONTask {
+        return stream.postSearchStreamRules(request)
+    }
+    public func searchStream(_ request: GetTweetsSearchStreamRequestV2) -> TwitterAPISessionStreamTask {
+        return stream.searchStream(request)
+    }
+
+    // MARK: - TimelineAPIv2
+
+    public func getUserTweets(_ request: GetUsersTweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return timeline.getUserTweets(request)
+    }
+    public func getUserMensions(_ request: GetUsersMentionsRequestV2) -> TwitterAPISessionJSONTask {
+        return timeline.getUserMensions(request)
+    }
+    public func getUserReverseChronological(_ request: GetUsersTimelinesReverseChronologicalRequestV2) -> TwitterAPISessionJSONTask {
+        return timeline.getUserReverseChronological(request)
+    }
+
+    // MARK: - TweetAPIv2
+
+    public func getTweets(_ request: GetTweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return tweet.getTweets(request)
+    }
+    public func getTweet(_ request: GetTweetRequestV2) -> TwitterAPISessionJSONTask {
+        return tweet.getTweet(request)
+    }
+    public func getQuoteTweets(_ request: GetTweetsQuoteTweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return tweet.getQuoteTweets(request)
+    }
+    public func deleteTweet(_ request: DeleteTweetRequestV2) -> TwitterAPISessionJSONTask {
+        return tweet.deleteTweet(request)
+    }
+    public func postTweet(_ request: PostTweetsRequestV2) -> TwitterAPISessionJSONTask {
+        return tweet.postTweet(request)
+    }
+    public func hideReply(_ request: PutTweetsHiddenRequestV2) -> TwitterAPISessionJSONTask {
+        return tweet.hideReply(request)
+    }
+
+    // MARK: - TweetCountAPIv2
+
+    public func getTweetCountRecent(_ request: GetTweetsCountsRecentRequestV2) -> TwitterAPISessionJSONTask {
+        return tweetCount.getTweetCountRecent(request)
+    }
+    public func getTweetCountAll(_ request: GetTweetsCountsAllRequestV2) -> TwitterAPISessionJSONTask {
+        return tweetCount.getTweetCountAll(request)
+    }
+
+    // MARK: - UserAPIv2
+
+    public func getUser(_ request: GetUserRequestV2) -> TwitterAPISessionJSONTask {
+        return user.getUser(request)
+    }
+    public func getUsers(_ request: GetUsersRequestV2) -> TwitterAPISessionJSONTask {
+        return user.getUsers(request)
+    }
+    public func getUserByUsername(_ request: GetUsersByUsernameRequestV2) -> TwitterAPISessionJSONTask {
+        return user.getUserByUsername(request)
+    }
+    public func getUsersByUsernames(_ request: GetUsersByRequestV2) -> TwitterAPISessionJSONTask {
+        return user.getUsersByUsernames(request)
+    }
+    public func getMe(_ request: GetUsersMeRequestV2) -> TwitterAPISessionJSONTask {
+        return user.getMe(request)
+    }
+}

--- a/Sources/TwitterAPIKit/TwitterAPIClient.swift
+++ b/Sources/TwitterAPIKit/TwitterAPIClient.swift
@@ -56,13 +56,3 @@ open class TwitterAPIBase {
         self.session = session
     }
 }
-
-extension TwitterAPIClient {
-
-    class TwitterAPIImplV2 {
-        let session: TwitterAPISession
-        init(session: TwitterAPISession) {
-            self.session = session
-        }
-    }
-}

--- a/Sources/TwitterAPIKit/TwitterAPIClient.swift
+++ b/Sources/TwitterAPIKit/TwitterAPIClient.swift
@@ -27,7 +27,7 @@ open class TwitterAPIClient {
             configuration: configuration,
             environment: environment
         )
-        self.auth = TwitterAuthAPIImpl(session: session)
+        self.auth = TwitterAuthAPI(session: session)
         v1 = TwitterAPIImplV1(session: session)
         v2 = TwitterAPIImplV2(session: session)
     }
@@ -50,14 +50,14 @@ open class TwitterAPIClient {
     }
 }
 
-extension TwitterAPIClient {
-
-    class TwitterAuthAPIImpl {
-        let session: TwitterAPISession
-        init(session: TwitterAPISession) {
-            self.session = session
-        }
+open class TwitterAPIBase {
+    public let session: TwitterAPISession
+    public init(session: TwitterAPISession) {
+        self.session = session
     }
+}
+
+extension TwitterAPIClient {
 
     class TwitterAPIImplV1 {
         let session: TwitterAPISession

--- a/Sources/TwitterAPIKit/TwitterAPIClient.swift
+++ b/Sources/TwitterAPIKit/TwitterAPIClient.swift
@@ -28,7 +28,7 @@ open class TwitterAPIClient {
             environment: environment
         )
         self.auth = TwitterAuthAPI(session: session)
-        v1 = TwitterAPIImplV1(session: session)
+        v1 = TwitterAPIv1(session: session)
         v2 = TwitterAPIImplV2(session: session)
     }
 
@@ -58,13 +58,6 @@ open class TwitterAPIBase {
 }
 
 extension TwitterAPIClient {
-
-    class TwitterAPIImplV1 {
-        let session: TwitterAPISession
-        init(session: TwitterAPISession) {
-            self.session = session
-        }
-    }
 
     class TwitterAPIImplV2 {
         let session: TwitterAPISession

--- a/Sources/TwitterAPIKit/TwitterAPIClient.swift
+++ b/Sources/TwitterAPIKit/TwitterAPIClient.swift
@@ -29,7 +29,7 @@ open class TwitterAPIClient {
         )
         self.auth = TwitterAuthAPI(session: session)
         v1 = TwitterAPIv1(session: session)
-        v2 = TwitterAPIImplV2(session: session)
+        v2 = TwitterAPIv2(session: session)
     }
 
     convenience public init(

--- a/flat-api.sh
+++ b/flat-api.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Usage:
+# ./flat-api.sh: Generate Code
+# ./flat-api.sh -c: Check if the code has already been generated. (For CI)
+
+if ! which sourcery > /dev/null; then
+  echo "warning: sourcery not installed, download from https://github.com/krzysztofzablocki/Sourcery"
+  exit 1
+fi
+
+while getopts c OPT
+do
+  case $OPT in
+    "c" ) CHECK="TRUE" ;;
+  esac
+done
+
+OUTPUT="Sources/TwitterAPIKit/TwitterAPI+Flat.generated.swift"
+
+sourcery --sources Sources/TwitterAPIKit --templates gen-flat-api.stencil --output ${OUTPUT}
+
+if [ "$CHECK" = "TRUE" ]; then
+    if ! git diff --exit-code ${OUTPUT} > /dev/null; then
+        echo "Error: There is a difference in ${OUTPUT}. Please generate code and commit." 1>&2
+        exit 1
+    fi
+fi

--- a/gen-flat-api.stencil
+++ b/gen-flat-api.stencil
@@ -1,0 +1,21 @@
+// swift-format-ignore-file
+import Foundation
+{% set Classes "TwitterAuthAPI,TwitterAPIv1,TwitterAPIv2"|split:"," %}
+{% for apiClass in Classes %}
+
+extension {{apiClass}} {
+{% for property in type[apiClass].variables %}
+
+    // MARK: - {{property.typeName}}
+
+    {% for method in property.type.methods where method.accessLevel == "public" %}
+    public func {{ method.name }}{{ ' async' if method.isAsync }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+        {% if not method.returnTypeName.isVoid %}return {%endif%}{{property.name}}.{{method.callName}}({% for argument in method.parameters %}{%if argument.argumentLabel != nil%}{{argument.argumentLabel}}: {%endif%}{% if variable.name == argument.name %}{{variable.name}}{% else %}{{type.name|lowercase}}{{argument.name}}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})
+    }
+    {% endfor %}
+{% endfor %}
+}
+{% endfor %}
+{# Run
+sourcery --sources Sources/TwitterAPIKit --templates gen-flat-api.stencil --output Sources/TwitterAPIKit/TwitterAPI+Flat.generated.swift
+#}


### PR DESCRIPTION
We chose to use classes for the following reasons.

Protocols are not scalable.

Protocols make it difficult to write extensions such as RxSwift's Reactive.